### PR TITLE
combine two properties

### DIFF
--- a/ogcapi-draft/ogcapi-html/src/main/java/de/ii/ldproxy/target/html/FeatureTransformerHtml.java
+++ b/ogcapi-draft/ogcapi-html/src/main/java/de/ii/ldproxy/target/html/FeatureTransformerHtml.java
@@ -77,6 +77,7 @@ public class FeatureTransformerHtml implements FeatureTransformer2, OnTheFly {
     private PropertyDTO currentGeometryPart;
     private int currentGeometryParts;
     private boolean currentGeometryWritten;
+    private boolean combineCurrentPropertyValues;
 
     public FeatureTransformerHtml(FeatureTransformationContextHtml transformationContext, HttpClient httpClient) {
         this.outputStreamWriter = new OutputStreamWriter(transformationContext.getOutputStream());
@@ -309,6 +310,15 @@ public class FeatureTransformerHtml implements FeatureTransformer2, OnTheFly {
     @Override
     public void onPropertyStart(FeatureProperty featureProperty, List<Integer> multiplicities) throws Exception {
         currentFeatureProperty = featureProperty;
+
+        if (featureProperty.getPath().indexOf(":", featureProperty.getPath().lastIndexOf("/")) > 0) {
+            if (combineCurrentPropertyValues) {
+                this.combineCurrentPropertyValues = false;
+                currentValue.append("|||");
+            } else {
+                this.combineCurrentPropertyValues = true;
+            }
+        }
     }
 
     @Override
@@ -318,6 +328,10 @@ public class FeatureTransformerHtml implements FeatureTransformer2, OnTheFly {
 
     @Override
     public void onPropertyEnd() throws Exception {
+        if (combineCurrentPropertyValues) {
+            return;
+        }
+
         if (currentValue.length() > 0) {
             writeField(currentFeatureProperty, currentValue.toString());
             currentValue.setLength(0);

--- a/ogcapi-draft/ogcapi-html/src/main/java/de/ii/ldproxy/target/html/FeatureTransformerHtmlComplexObjects.java
+++ b/ogcapi-draft/ogcapi-html/src/main/java/de/ii/ldproxy/target/html/FeatureTransformerHtmlComplexObjects.java
@@ -85,6 +85,7 @@ public class FeatureTransformerHtmlComplexObjects implements FeatureTransformer2
     private ValueDTO currentValue = null;
     private FeatureProperty currentProperty = null;
     private ArrayList<FeatureProperty> currentFeatureProperties = null;
+    private boolean combineCurrentPropertyValues;
 
     private ValueDTO getValue(FeatureProperty baseProperty, FeatureProperty htmlProperty, List<Integer> index) {
         String htmlName = htmlProperty.getName();
@@ -381,6 +382,15 @@ public class FeatureTransformerHtmlComplexObjects implements FeatureTransformer2
             currentValue = getValue(featureProperty, featureProperty, index);
             updatePropertySortPriorities(currentValue.property, sortPriority);
         }
+
+        if (featureProperty.getPath().indexOf(":", featureProperty.getPath().lastIndexOf("/")) > 0) {
+            if (combineCurrentPropertyValues) {
+                this.combineCurrentPropertyValues = false;
+                currentValueBuilder.append("|||");
+            } else {
+                this.combineCurrentPropertyValues = true;
+            }
+        }
     }
 
     private void updatePropertySortPriorities(PropertyDTO property, int sortPriority) {
@@ -400,6 +410,10 @@ public class FeatureTransformerHtmlComplexObjects implements FeatureTransformer2
 
     @Override
     public void onPropertyEnd() throws Exception {
+        if (combineCurrentPropertyValues) {
+            return;
+        }
+
         if (Objects.nonNull(currentValue)) {
             String value = currentValueBuilder.toString();
 

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -3,7 +3,7 @@ dependencies {
     feature group: 'de.interactive_instruments', name: 'xtraplatform-base', version: '2.2.2'
     feature group: 'de.interactive_instruments', name: 'xtraplatform-store', version: '2.2.6'
     feature group: 'de.interactive_instruments', name: 'xtraplatform-web', version: '2.2.2'
-    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.2.13'
+    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.2.15'
 }
 
 allprojects {


### PR DESCRIPTION
This allows to combine two columns from the same table. To enable it, in the property path in the provider configuration, define two columns separated by `:`, e.g.:

```
process:
    path: /observation/[process_fk=id]process/category_fk:id
    type: STRING
```

The value for `process` will then be the values of the two columns separated by `|||`.

In the service configuration, `stringFormat` can be then be used like this:

```
process:
    stringFormat: "{{serviceUrl}}/collections/process/{{value | replace:'\\|\\|\\|':'/items/'}}"
```

A cleaner solution that removes the `|||` seperator should be considered in the context of #162. It would require to implement transformers in the provider. The above example would then require two `stringFormat`, one in the provider and one in the service:

```
stringFormat: /collections/process/{{category_fk}}/items/{{id}}"
```

```
stringFormat: "{{serviceUrl}}{{value}}"
```

