### PR TITLE
sort keys and constants

### DIFF
--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -7,7 +7,7 @@ dependencies {
     }
     feature group: 'de.interactive_instruments', name: 'xtraplatform-store', version: '2.2.13'
     feature group: 'de.interactive_instruments', name: 'xtraplatform-web', version: '2.2.4'
-    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.3.4'
+    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.3.5'
 }
 
 allprojects {

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -7,7 +7,7 @@ dependencies {
     }
     feature group: 'de.interactive_instruments', name: 'xtraplatform-store', version: '2.2.13'
     feature group: 'de.interactive_instruments', name: 'xtraplatform-web', version: '2.2.4'
-    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.3.5'
+    feature group: 'de.interactive_instruments', name: 'xtraplatform-sdi-tools', version: '3.3.6'
 }
 
 allprojects {


### PR DESCRIPTION
Fixes #192. 

### sort keys

Every table with mapped columns needs a sort key. Until now it was expected that every table has a numeric column with the same name that is used as sort key. The default sort key column name was already configurable:

```yml
connectionInfo:
  pathSyntax:
    defaultSortKey: id
```

This PR introduces support for string columns as sort key. Additionally it allows to set a different sort key per table:

```yml
managementrestrictionorregulationzone:
    sourcePath: /am_managementrestrictionorregulationzone{sortKey=inspireid}
    type: OBJECT
    properties:
      legislationCitation:
        sourcePath: '[id=id_managementrestrictionorregulationzone]am_manrestreg_legcit/[id_legislationcitation=id]am_legislationcitation{sortKey=identificationnumber}'
        type: OBJECT_ARRAY
```

Only the table at the end of the path should need a sort key, because that is the one with mapped columns.

### constants

This PR introduces support for constant values instead of column mappings.

```yml
name:
#  sourcePath: name
  constantValue: FOO
  type: STRING
```

When using `constantValue`, you don't need to define `sourcePath`.

