### PR TITLE
Fix generation of multi-layer tiles

### DIFF
--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/MbStyleLayer.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/MbStyleLayer.java
@@ -11,11 +11,31 @@ import java.util.Optional;
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true)
 @JsonDeserialize(as = ImmutableMbStyleLayer.class)
 public abstract class MbStyleLayer {
-    public enum LayerType { background, fill, line, symbol, raster, circle, fillExtrusion, heatmap, hillshade }
+    public enum LayerType {
+        background("background"),
+        fill("fill"),
+        line("line"),
+        symbol("symbol"),
+        raster("raster"),
+        circle("circle"),
+        fillExtrusion("fill-extrusion"),
+        heatmap("heatmap"),
+        hillshade("hillshade");
+
+        public final String label;
+
+        LayerType(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() { return label; };
+    }
 
     public abstract String getId();
 
-    public abstract LayerType getType();
+    // TODO use enum to check that we have a valid value
+    public abstract String getType();
 
     public abstract Optional<Object> getMetadata();
 

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/MbStyleStylesheet.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/MbStyleStylesheet.java
@@ -26,8 +26,10 @@ public abstract class MbStyleStylesheet {
     public abstract Optional<Object> getMetadata();
     public abstract Optional<List<Double>> getCenter();
     public abstract Optional<Double> getZoom();
-    public Optional<Double> getBearing() { return Optional.of(0.0); }
-    public Optional<Double> getPitch() { return Optional.of(0.0); }
+    @Value.Default
+    public Double getBearing() { return 0.0; }
+    @Value.Default
+    public Double getPitch() { return 0.0; }
     public abstract Optional<MbStyleLight> getLight();
     public abstract Map<String, MbStyleSource> getSources();
     public abstract Optional<String> getSprite();

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileMultiCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileMultiCollection.java
@@ -235,7 +235,6 @@ public class EndpointTileMultiCollection extends Endpoint {
                             if (Objects.nonNull(levels) && (levels.getMax() < level || levels.getMin() > level))
                                 return false;
 
-                            LOGGER.debug("Multi-layer tile {}/{}/{} includes collection {}", level, row, col, collection.getId());
                             return true;
                         })
                         .map(FeatureTypeConfiguration::getId)

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/VectorTileSeeding.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/VectorTileSeeding.java
@@ -387,21 +387,23 @@ public class VectorTileSeeding implements StartupTask {
                                             .collectionIds(ImmutableList.of(collectionId))
                                             .build()));
 
-                            // generate a query template for an arbitrary collection
-                            FeatureQuery query = outputFormat.getQuery(singleLayerTileMap.get(collectionIds.get(0)), ImmutableList.of(), ImmutableMap.of(), tilesConfiguration.get(), uriCustomizer);
-
                             Map<String, FeatureQuery> queryMap = collectionIds.stream()
-                                    .collect(ImmutableMap.toImmutableMap(collectionId -> collectionId, collectionId -> {
-                                        String featureTypeId = apiData.getCollections()
-                                                                      .get(collectionId)
-                                                                      .getExtension(FeaturesCoreConfiguration.class)
-                                                                      .map(cfg -> cfg.getFeatureType().orElse(collectionId))
-                                                                      .orElse(collectionId);
-                                        return ImmutableFeatureQuery.builder()
-                                            .from(query)
-                                            .type(featureTypeId)
-                                            .build();
-                                    }));
+                                                                              .collect(ImmutableMap.toImmutableMap(collectionId -> collectionId, collectionId -> {
+                                                                                  String featureTypeId = apiData.getCollections()
+                                                                                                                .get(collectionId)
+                                                                                                                .getExtension(FeaturesCoreConfiguration.class)
+                                                                                                                .map(cfg -> cfg.getFeatureType().orElse(collectionId))
+                                                                                                                .orElse(collectionId);
+                                                                                  TilesConfiguration layerConfiguration = apiData.getCollections()
+                                                                                                                                 .get(collectionId)
+                                                                                                                                 .getExtension(TilesConfiguration.class)
+                                                                                                                                 .orElse(tilesConfiguration.get());
+                                                                                  FeatureQuery query = outputFormat.getQuery(singleLayerTileMap.get(collectionId), ImmutableList.of(), ImmutableMap.of(), layerConfiguration, requestContext.getUriCustomizer());
+                                                                                  return ImmutableFeatureQuery.builder()
+                                                                                                              .from(query)
+                                                                                                              .type(featureTypeId)
+                                                                                                              .build();
+                                                                              }));
 
                             FeaturesCoreConfiguration coreConfiguration = apiData.getExtension(FeaturesCoreConfiguration.class).get();
 


### PR DESCRIPTION
While generating multi-layer tiles, the configuration for the specific collection/layer was not always taken into account (in the multi-layer tile request and during seeding).

In addition, the mapbox style support was improved to support bearing and pitch as well as extrusion layers.
