### PR TITLE
fix api definition caching

### DIFF
--- a/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/app/EndpointQueryables.java
+++ b/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/app/EndpointQueryables.java
@@ -84,8 +84,8 @@ public class EndpointQueryables extends EndpointSubCollection implements Conform
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_QUERYABLES);
@@ -117,10 +117,10 @@ public class EndpointQueryables extends EndpointSubCollection implements Conform
                     definitionBuilder.putResources(resourcePath, resourceBuilder.build());
                 }
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/EndpointSchema.java
+++ b/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/EndpointSchema.java
@@ -77,8 +77,8 @@ public class EndpointSchema extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_SCHEMA);
@@ -110,10 +110,10 @@ public class EndpointSchema extends EndpointSubCollection {
                     definitionBuilder.putResources(resourcePath, resourceBuilder.build());
                 }
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-draft/ogcapi-collections-style-info/src/main/java/de/ii/ldproxy/ogcapi/collections/styleinfo/EndpointManageStyleInfo.java
+++ b/ogcapi-draft/ogcapi-collections-style-info/src/main/java/de/ii/ldproxy/ogcapi/collections/styleinfo/EndpointManageStyleInfo.java
@@ -103,8 +103,8 @@ public class EndpointManageStyleInfo extends EndpointSubCollection implements Co
 
     @Override
     public ApiEndpointDefinition getDefinition(OgcApiDataV2 apiData) {
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_STYLE_INFO);
@@ -136,10 +136,10 @@ public class EndpointManageStyleInfo extends EndpointSubCollection implements Co
                     definitionBuilder.putResources(resourcePath, resourceBuilder.build());
                 }
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
+++ b/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
@@ -116,8 +116,8 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
 
     @Override
     public ApiEndpointDefinition getDefinition(OgcApiDataV2 apiData) {
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_FEATURES_JSONLD_CONTEXT);
@@ -160,9 +160,9 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
                     definitionBuilder.putResources(resourcePath, resourceBuilder.build());
                 }
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 }

--- a/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointDapa.java
+++ b/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointDapa.java
@@ -102,8 +102,8 @@ public class EndpointDapa extends EndpointSubCollection implements ConformanceCl
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(10000);
@@ -135,10 +135,10 @@ public class EndpointDapa extends EndpointSubCollection implements ConformanceCl
                         });
 
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointObservationProcessing.java
+++ b/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointObservationProcessing.java
@@ -105,8 +105,8 @@ public class EndpointObservationProcessing extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(10020);
@@ -269,10 +269,10 @@ public class EndpointObservationProcessing extends EndpointSubCollection {
                                 });
                     });
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointVariables.java
+++ b/ogcapi-draft/ogcapi-observation-processing/src/main/java/de/ii/ldproxy/ogcapi/observation_processing/application/EndpointVariables.java
@@ -79,8 +79,8 @@ public class EndpointVariables extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(10010);
@@ -112,10 +112,10 @@ public class EndpointVariables extends EndpointSubCollection {
                         });
 
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-draft/ogcapi-resources-manager/src/main/java/ii/de/ldproxy/resources/manager/EndpointResourcesManager.java
+++ b/ogcapi-draft/ogcapi-resources-manager/src/main/java/ii/de/ldproxy/resources/manager/EndpointResourcesManager.java
@@ -126,8 +126,8 @@ public class EndpointResourcesManager extends Endpoint implements ConformanceCla
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             Optional<StylesConfiguration> stylesExtension = apiData.getExtension(StylesConfiguration.class);
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("resources")
@@ -167,10 +167,10 @@ public class EndpointResourcesManager extends Endpoint implements ConformanceCla
                 resourceBuilder.putOperations(method.name(), operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/EndpointResource.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/EndpointResource.java
@@ -104,8 +104,8 @@ public class EndpointResource extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("resources")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_RESOURCE);
@@ -127,10 +127,10 @@ public class EndpointResource extends Endpoint {
                 definitionBuilder.putResources(path, resourceBuilder.build());
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/EndpointResources.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/EndpointResources.java
@@ -98,8 +98,8 @@ public class EndpointResources extends Endpoint implements ConformanceClass {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("resources")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_RESOURCES);
@@ -117,10 +117,10 @@ public class EndpointResources extends Endpoint implements ConformanceClass {
                 resourceBuilderSet.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilderSet.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-styles-manager/src/main/java/de/ii/ldproxy/ogcapi/styles/app/manager/EndpointStyleMetadataManager.java
+++ b/ogcapi-draft/ogcapi-styles-manager/src/main/java/de/ii/ldproxy/ogcapi/styles/app/manager/EndpointStyleMetadataManager.java
@@ -147,8 +147,8 @@ public class EndpointStyleMetadataManager extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("styles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_STYLE_METADATA_MANAGER);
@@ -248,10 +248,10 @@ public class EndpointStyleMetadataManager extends Endpoint {
                 resourceBuilder.putOperations(method.name(), operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-styles-manager/src/main/java/de/ii/ldproxy/ogcapi/styles/app/manager/EndpointStylesManager.java
+++ b/ogcapi-draft/ogcapi-styles-manager/src/main/java/de/ii/ldproxy/ogcapi/styles/app/manager/EndpointStylesManager.java
@@ -169,8 +169,8 @@ public class EndpointStylesManager extends Endpoint implements ConformanceClass 
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             Optional<StylesConfiguration> stylesExtension = apiData.getExtension(StylesConfiguration.class);
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("styles")
@@ -239,10 +239,10 @@ public class EndpointStylesManager extends Endpoint implements ConformanceClass 
                 resourceBuilder.putOperations("DELETE", operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyle.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyle.java
@@ -114,8 +114,8 @@ public class EndpointStyle extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("styles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_STYLESHEET);
@@ -138,10 +138,10 @@ public class EndpointStyle extends Endpoint {
                 definitionBuilder.putResources(path, resourceBuilder.build());
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyleMetadata.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyleMetadata.java
@@ -110,8 +110,8 @@ public class EndpointStyleMetadata extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("styles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_STYLE_METADATA);
@@ -136,10 +136,10 @@ public class EndpointStyleMetadata extends Endpoint {
                 definitionBuilder.putResources(path, resourceBuilder.build());
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyles.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/EndpointStyles.java
@@ -88,8 +88,8 @@ public class EndpointStyles extends Endpoint implements ConformanceClass {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("styles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_STYLES);
@@ -107,10 +107,10 @@ public class EndpointStyles extends Endpoint implements ConformanceClass {
                 resourceBuilderSet.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilderSet.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileMultiCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileMultiCollection.java
@@ -126,8 +126,8 @@ public class EndpointTileMultiCollection extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("tiles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE);
@@ -147,10 +147,10 @@ public class EndpointTileMultiCollection extends Endpoint {
                 resourceBuilder.putOperations(method.name(), operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @Path("/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetMultiCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetMultiCollection.java
@@ -79,8 +79,8 @@ public class EndpointTileSetMultiCollection extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("tiles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_SET);
@@ -98,10 +98,10 @@ public class EndpointTileSetMultiCollection extends Endpoint {
                 resourceBuilderSet.putOperations(method.name(), operation);
             definitionBuilder.putResources(path, resourceBuilderSet.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetSingleCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetSingleCollection.java
@@ -82,8 +82,8 @@ public class EndpointTileSetSingleCollection extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_SET_COLLECTION);
@@ -117,10 +117,10 @@ public class EndpointTileSetSingleCollection extends EndpointSubCollection {
                 }
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetsMultiCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetsMultiCollection.java
@@ -85,8 +85,8 @@ public class EndpointTileSetsMultiCollection extends Endpoint implements Conform
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("tiles")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_SETS);
@@ -103,10 +103,10 @@ public class EndpointTileSetsMultiCollection extends Endpoint implements Conform
                 resourceBuilderSet.putOperations(method.name(), operation);
             definitionBuilder.putResources(path, resourceBuilderSet.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @Path("")

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetsSingleCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSetsSingleCollection.java
@@ -94,8 +94,8 @@ public class EndpointTileSetsSingleCollection extends EndpointSubCollection impl
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_SETS_COLLECTION);
@@ -130,10 +130,10 @@ public class EndpointTileSetsSingleCollection extends EndpointSubCollection impl
                 }
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSingleCollection.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/EndpointTileSingleCollection.java
@@ -124,8 +124,8 @@ public class EndpointTileSingleCollection extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_COLLECTION);
@@ -161,10 +161,10 @@ public class EndpointTileSingleCollection extends EndpointSubCollection {
                 }
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @Path("/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/tileMatrixSet/EndpointTileMatrixSets.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/tileMatrixSet/EndpointTileMatrixSets.java
@@ -91,8 +91,8 @@ public class EndpointTileMatrixSets extends Endpoint implements ConformanceClass
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("tileMatrixSets")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_TILE_MATRIX_SETS);
@@ -127,10 +127,10 @@ public class EndpointTileMatrixSets extends Endpoint implements ConformanceClass
                 definitionBuilder.putResources(path, resourceBuilder.build());
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     /**

--- a/ogcapi-draft/ogcapi-transactional/src/main/java/de/ii/ldproxy/ogcapi/features/transactional/EndpointTransactional.java
+++ b/ogcapi-draft/ogcapi-transactional/src/main/java/de/ii/ldproxy/ogcapi/features/transactional/EndpointTransactional.java
@@ -101,8 +101,8 @@ public class EndpointTransactional extends EndpointSubCollection {
 
     @Override
     public ApiEndpointDefinition getDefinition(OgcApiDataV2 apiData) {
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_FEATURES_TRANSACTION);
@@ -171,10 +171,10 @@ public class EndpointTransactional extends EndpointSubCollection {
                 }
 
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @Path("/{id}/items")

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollection.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollection.java
@@ -82,8 +82,8 @@ public class EndpointCollection extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_COLLECTION);
@@ -127,10 +127,10 @@ public class EndpointCollection extends EndpointSubCollection {
                 }
             }
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollections.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollections.java
@@ -73,8 +73,8 @@ public class EndpointCollections extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_COLLECTIONS);
@@ -104,10 +104,10 @@ public class EndpointCollections extends Endpoint {
                 resourceBuilder.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointConformance.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointConformance.java
@@ -63,8 +63,8 @@ public class EndpointConformance extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("conformance")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_CONFORMANCE);
@@ -83,10 +83,10 @@ public class EndpointConformance extends Endpoint {
                 resourceBuilder.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointDefinition.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointDefinition.java
@@ -62,8 +62,8 @@ public class EndpointDefinition extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("api")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_API_DEFINITION);
@@ -87,10 +87,10 @@ public class EndpointDefinition extends Endpoint {
                 resourceBuilder.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
 
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointLandingPage.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointLandingPage.java
@@ -62,8 +62,8 @@ public class EndpointLandingPage extends Endpoint {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_LANDING_PAGE);
@@ -79,10 +79,10 @@ public class EndpointLandingPage extends Endpoint {
             if (operation!=null)
                 resourceBuilder.putOperations("GET", operation);
             definitionBuilder.putResources(path, resourceBuilder.build());
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @GET

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/EndpointFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/EndpointFeatures.java
@@ -99,8 +99,9 @@ public class EndpointFeatures extends EndpointSubCollection {
         if (!isEnabledForApi(apiData))
             return super.getDefinition(apiData);
 
-        String apiId = apiData.getId();
-        if (!apiDefinitions.containsKey(apiId)) {
+        int apiDataHash = apiData.hashCode();
+        if (!apiDefinitions.containsKey(apiDataHash)) {
+            LOGGER.info("OAPI GEN");
             ImmutableApiEndpointDefinition.Builder definitionBuilder = new ImmutableApiEndpointDefinition.Builder()
                     .apiEntrypoint("collections")
                     .sortPriority(ApiEndpointDefinition.SORT_PRIORITY_FEATURES);
@@ -171,10 +172,10 @@ public class EndpointFeatures extends EndpointSubCollection {
                 }
 
             }
-            apiDefinitions.put(apiId, definitionBuilder.build());
+            apiDefinitions.put(apiDataHash, definitionBuilder.build());
         }
 
-        return apiDefinitions.get(apiId);
+        return apiDefinitions.get(apiDataHash);
     }
 
     @Override

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Endpoint.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Endpoint.java
@@ -24,7 +24,7 @@ public abstract class Endpoint implements EndpointExtension {
     );
 
     protected final ExtensionRegistry extensionRegistry;
-    protected Map<String, ApiEndpointDefinition> apiDefinitions;
+    protected Map<Integer, ApiEndpointDefinition> apiDefinitions;
     protected List<? extends FormatExtension> formats;
 
     /**


### PR DESCRIPTION
The api definition caching did not take into account that configurations may change at runtime. I changed the cache key from the id to a hashsum to address this.