### PR TITLE
Fix error 404 for features with a dot symbol in the ID

### DIFF
--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/PathParameterFeatureIdFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/PathParameterFeatureIdFeatures.java
@@ -34,7 +34,7 @@ public class PathParameterFeatureIdFeatures implements OgcApiPathParameter {
 
     @Override
     public String getPattern() {
-        return "[\\w(\\-|\\.)]+";
+        return "[\\w\\-\\.]+";
     }
 
     @Override

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/PathParameterFeatureIdFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/PathParameterFeatureIdFeatures.java
@@ -34,7 +34,7 @@ public class PathParameterFeatureIdFeatures implements OgcApiPathParameter {
 
     @Override
     public String getPattern() {
-        return "[\\w\\-]+";
+        return "[\\w(\\-|\\.)]+";
     }
 
     @Override


### PR DESCRIPTION
Feature ID URI pattern now allows a dot symbol to avoid 404 errors for features with a dot symbol