### PR TITLE
extent merging still not correct

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/OgcApiDataV2.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/OgcApiDataV2.java
@@ -165,7 +165,7 @@ public abstract class OgcApiDataV2 implements ServiceData, ExtendableConfigurati
             if (collectionsHaveMissingExtents) {
                 mergedCollections.values()
                     .stream()
-                    .filter(featureTypeConfigurationOgcApi -> featureTypeConfigurationOgcApi.getExtent().isEmpty())
+                    .filter(featureTypeConfigurationOgcApi -> isToBeMerged(getDefaultExtent().get(), featureTypeConfigurationOgcApi.getExtent()))
                     .forEach(featureTypeConfigurationOgcApi -> mergedCollections
                         .put(featureTypeConfigurationOgcApi.getId(),
                             featureTypeConfigurationOgcApi.getBuilder()


### PR DESCRIPTION
The previous fix for merging extents did not cover all cases. This could lead to infinite recursion.