### PR TITLE
GeoJSON-LD startup fix

### DIFF
--- a/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/ContextFormatExtension.java
+++ b/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/ContextFormatExtension.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ldproxy.ogcapi.features.geojsonld.app;
+
+import de.ii.ldproxy.ogcapi.domain.FormatExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static de.ii.ldproxy.ogcapi.collections.domain.AbstractPathParameterCollectionId.COLLECTION_ID_PATTERN;
+
+public interface ContextFormatExtension extends FormatExtension {
+
+    default String getPathPattern() {
+        return "^/?collections/"+COLLECTION_ID_PATTERN+"/context/?$";
+    }
+
+    default InputStream getInputStream(Path context) throws IOException {
+        return Files.newInputStream(context);
+    }
+}

--- a/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/ContextFormatJsonLd.java
+++ b/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/ContextFormatJsonLd.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2021 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ldproxy.ogcapi.features.geojsonld.app;
+
+import de.ii.ldproxy.ogcapi.domain.ApiMediaType;
+import de.ii.ldproxy.ogcapi.domain.ApiMediaTypeContent;
+import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
+import de.ii.ldproxy.ogcapi.domain.ImmutableApiMediaType;
+import de.ii.ldproxy.ogcapi.domain.ImmutableApiMediaTypeContent;
+import de.ii.ldproxy.ogcapi.domain.OgcApiDataV2;
+import de.ii.ldproxy.ogcapi.features.geojson.domain.GeoJsonConfiguration;
+import de.ii.ldproxy.ogcapi.features.geojsonld.domain.GeoJsonLdConfiguration;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import org.apache.felix.ipojo.annotations.Component;
+import org.apache.felix.ipojo.annotations.Instantiate;
+import org.apache.felix.ipojo.annotations.Provides;
+
+import javax.ws.rs.core.MediaType;
+
+@Component
+@Provides
+@Instantiate
+public class ContextFormatJsonLd implements ContextFormatExtension {
+
+    public static final ApiMediaType MEDIA_TYPE = new ImmutableApiMediaType.Builder()
+            .type(new MediaType("application", "ld+json"))
+            .label("JSON-LD")
+            .parameter("jsonld")
+            .build();
+
+    @Override
+    public ApiMediaType getMediaType() {
+        return MEDIA_TYPE;
+    }
+
+    @Override
+    public Class<? extends ExtensionConfiguration> getBuildingBlockConfigurationType() {
+        return GeoJsonLdConfiguration.class;
+    }
+
+    @Override
+    public boolean isEnabledForApi(OgcApiDataV2 apiData) {
+        return apiData.getCollections()
+                      .values()
+                      .stream()
+                      .anyMatch(collectionData -> collectionData.getExtension(getBuildingBlockConfigurationType())
+                                                                .map(cfg -> cfg.isEnabled())
+                                                                .orElse(false) &&
+                                                  collectionData.getExtension(GeoJsonConfiguration.class)
+                                                                .map(cfg -> cfg.isEnabled())
+                                                                .orElse(true));
+    }
+
+    @Override
+    public boolean isEnabledForApi(OgcApiDataV2 apiData, String collectionId) {
+        return apiData.getCollections()
+                      .get(collectionId)
+                      .getExtension(getBuildingBlockConfigurationType())
+                      .map(cfg -> cfg.isEnabled())
+                      .orElse(false) &&
+                apiData.getCollections()
+                       .get(collectionId)
+                       .getExtension(GeoJsonConfiguration.class)
+                       .map(cfg -> cfg.isEnabled())
+                       .orElse(true);
+    }
+
+    @Override
+    public ApiMediaTypeContent getContent(OgcApiDataV2 apiData, String path) {
+        return new ImmutableApiMediaTypeContent.Builder()
+                .schema(new ObjectSchema())
+                .schemaRef("#/components/schemas/anyObject")
+                // TODO propert JSON-LD context schema
+                .ogcApiMediaType(MEDIA_TYPE)
+                .build();
+    }
+}

--- a/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
+++ b/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
@@ -96,7 +96,7 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
         java.nio.file.Path context = getContextPath(api.getId(), collectionId, format.getMediaType().parameter());
 
         if (!Files.isRegularFile(context)) {
-            throw new NotFoundException(String.format("The {} context was not found.", format.getMediaType().label()));
+            throw new NotFoundException(String.format("The %s context was not found.", format.getMediaType().label()));
         }
 
         // TODO validate, that it is a valid JSON-LD Context document

--- a/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
+++ b/ogcapi-draft/ogcapi-features-geojson-ld/src/main/java/de/ii/ldproxy/ogcapi/features/geojsonld/app/EndpointJsonLdContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 interactive instruments GmbH
+ * Copyright 2021 interactive instruments GmbH
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,27 +8,22 @@
 package de.ii.ldproxy.ogcapi.features.geojsonld.app;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import de.ii.ldproxy.ogcapi.collections.domain.EndpointSubCollection;
 import de.ii.ldproxy.ogcapi.domain.ApiEndpointDefinition;
 import de.ii.ldproxy.ogcapi.domain.ApiMediaType;
-import de.ii.ldproxy.ogcapi.domain.ApiMediaTypeContent;
 import de.ii.ldproxy.ogcapi.domain.ApiOperation;
 import de.ii.ldproxy.ogcapi.domain.ApiRequestContext;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionRegistry;
 import de.ii.ldproxy.ogcapi.domain.FormatExtension;
-import de.ii.ldproxy.ogcapi.domain.HttpMethods;
 import de.ii.ldproxy.ogcapi.domain.ImmutableApiEndpointDefinition;
 import de.ii.ldproxy.ogcapi.domain.ImmutableApiMediaType;
-import de.ii.ldproxy.ogcapi.domain.ImmutableApiMediaTypeContent;
 import de.ii.ldproxy.ogcapi.domain.ImmutableOgcApiResourceAuxiliary;
 import de.ii.ldproxy.ogcapi.domain.OgcApi;
 import de.ii.ldproxy.ogcapi.domain.OgcApiDataV2;
 import de.ii.ldproxy.ogcapi.domain.OgcApiPathParameter;
 import de.ii.ldproxy.ogcapi.domain.OgcApiQueryParameter;
 import de.ii.ldproxy.ogcapi.features.geojsonld.domain.GeoJsonLdConfiguration;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import org.apache.felix.ipojo.annotations.Component;
 import org.apache.felix.ipojo.annotations.Instantiate;
 import org.apache.felix.ipojo.annotations.Provides;
@@ -38,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -48,13 +44,12 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static de.ii.ldproxy.ogcapi.domain.FoundationConfiguration.API_RESOURCES_DIR;
 import static de.ii.xtraplatform.runtime.domain.Constants.DATA_DIR_KEY;
-
 
 @Component
 @Provides
@@ -63,12 +58,6 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EndpointJsonLdContext.class);
     private static final List<String> TAGS = ImmutableList.of("Discover data collections");
-
-    private static final ApiMediaType MEDIA_TYPE = new ImmutableApiMediaType.Builder()
-            .type(new MediaType("application","ld+json"))
-            .label("JSON-LD")
-            .parameter("json")
-            .build();
 
     private final java.nio.file.Path contextDirectory;
 
@@ -84,9 +73,9 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
         return GeoJsonLdConfiguration.class;
     }
 
-    private java.nio.file.Path getContextPath(String apiId, String collectionId) {
+    private java.nio.file.Path getContextPath(String apiId, String collectionId, String extension) {
         return contextDirectory.resolve(apiId)
-                               .resolve(collectionId + ".jsonld");
+                               .resolve(collectionId + "." + extension);
     }
 
     @Path("/{collectionId}/context")
@@ -95,21 +84,32 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
     public Response getContext(@Context ApiRequestContext apiRequestContext, @Context OgcApi api,
                                @PathParam("collectionId") String collectionId) throws IOException {
 
-        java.nio.file.Path context = getContextPath(api.getId(), collectionId);
+        ContextFormatExtension format = extensionRegistry.getExtensionsForType(ContextFormatExtension.class)
+                                                         .stream()
+                                                         .filter(f -> f.isEnabledForApi(api.getData()))
+                                                         .filter(f -> f.getMediaType()
+                                                                       .matches(apiRequestContext.getMediaType()
+                                                                                                 .type()))
+                                                         .findFirst()
+                                                         .orElseThrow(() -> new NotAcceptableException(MessageFormat.format("The requested media type ''{0}'' is not supported for this resource.", apiRequestContext.getMediaType())));
+
+        java.nio.file.Path context = getContextPath(api.getId(), collectionId, format.getMediaType().parameter());
 
         if (!Files.isRegularFile(context)) {
-            throw new NotFoundException("The JSON-LD context was not found.");
+            throw new NotFoundException(String.format("The {} context was not found.", format.getMediaType().label()));
         }
 
         // TODO validate, that it is a valid JSON-LD Context document
 
-        return Response.ok(Files.newInputStream(context),"application/ld+json")
+        return Response.ok(format.getInputStream(context),"application/ld+json")
                        .build();
     }
 
     @Override
     public List<? extends FormatExtension> getFormats() {
-        return ImmutableList.of();
+        if (formats==null)
+            formats = extensionRegistry.getExtensionsForType(ContextFormatExtension.class);
+        return formats;
     }
 
     @Override
@@ -132,8 +132,12 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
                         collectionIdParam.getValues(apiData) :
                         ImmutableList.of("{collectionId}");
                 for (String collectionId : collectionIds) {
-                    if (explode && !Files.isRegularFile(getContextPath(apiData.getId(), collectionId)))
-                        // skip, if no context is available
+                    if (explode && !apiData.getCollections()
+                                           .get(collectionId)
+                                           .getExtension(GeoJsonLdConfiguration.class)
+                                           .map(cfg -> cfg.getEnabled())
+                                           .orElse(false))
+                        // skip, if disabled for the collection
                         continue;
                     final List<OgcApiQueryParameter> queryParameters = getQueryParameters(extensionRegistry, apiData, path, collectionId);
                     final String operationSummary = "retrieve the JSON-LD context for the feature collection '" + collectionId + "'";
@@ -142,15 +146,7 @@ public class EndpointJsonLdContext extends EndpointSubCollection {
                     ImmutableOgcApiResourceAuxiliary.Builder resourceBuilder = new ImmutableOgcApiResourceAuxiliary.Builder()
                             .path(resourcePath)
                             .pathParameters(pathParameters);
-                    Map<MediaType, ApiMediaTypeContent> responseContent = new ImmutableMap.Builder<MediaType, ApiMediaTypeContent>()
-                            .put(MEDIA_TYPE.type(),
-                                 new ImmutableApiMediaTypeContent.Builder()
-                                    .ogcApiMediaType(MEDIA_TYPE)
-                                    .schema(new ObjectSchema())
-                                    .schemaRef("#/components/schemas/json-ld-context")
-                                    .build())
-                            .build();
-                    ApiOperation operation = addOperation(apiData, HttpMethods.GET, responseContent, queryParameters, resourcePath, operationSummary, operationDescription, TAGS);
+                    ApiOperation operation = addOperation(apiData, queryParameters, resourcePath, operationSummary, operationDescription, TAGS);
                     if (operation!=null)
                         resourceBuilder.putOperations("GET", operation);
                     definitionBuilder.putResources(resourcePath, resourceBuilder.build());


### PR DESCRIPTION
The new onStartup() checks always failed for the GEO_JSON_LD module, because no FormatExtension was used for the context. The module has been updated to properly define and use a format extension.