### PR TITLE
add coordinatePrecision option

### DIFF
--- a/docs/de/configuration/services/building-blocks/features-core.md
+++ b/docs/de/configuration/services/building-blocks/features-core.md
@@ -14,6 +14,7 @@ In der Konfiguration können die folgenden Optionen gewählt werden:
 |Option |Datentyp |Default |Beschreibung
 | --- | --- | --- | ---
 |`defaultCrs` |string |"CRS84" |Setzt das Standard-Koordinatenreferenzsystem, entweder 'CRS84' für einen Datensatz mit 2D-Geometrien oder 'CRS84h' für einen Datensatz mit 3D-Geometrien.
+|`coordinatePrecision` |object |`{}` |Steuert, ob Koordinaten in Abhängig des verwendeten Koordinatenreferenzsystems auf eine bestimmte Anzahl von Stellen begrenzt werden. Anzugeben ist die Maßeinheit und die zugehörige Anzahl der Nachkommastellen. Beispiel: `{ "metre" : 2, "degree" : 7 }`. Gültige Maßeinheiten sind "metre" (bzw. "meter") und "degree".
 |`minimumPageSize` |int |1 |Setzt den Minimalwert für den Parameter `limit`.
 |`defaultPageSize` |int |10 |Setzt den Detaultwert für den Parameter `limit`.
 |`maximumPageSize` |int |10000 |Setzt den Maximalwert für den Parameter `limit`.

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesQueryImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesQueryImpl.java
@@ -7,6 +7,11 @@
  */
 package de.ii.ldproxy.ogcapi.features.core.app;
 
+import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.DATETIME_INTERVAL_SEPARATOR;
+import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_BBOX;
+import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_DATETIME;
+import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_Q;
+
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -41,20 +46,6 @@ import de.ii.xtraplatform.crs.domain.OgcCrs;
 import de.ii.xtraplatform.features.domain.FeatureQuery;
 import de.ii.xtraplatform.features.domain.FeatureQueryTransformer;
 import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery;
-import org.apache.felix.ipojo.annotations.Component;
-import org.apache.felix.ipojo.annotations.Instantiate;
-import org.apache.felix.ipojo.annotations.Provides;
-import org.apache.felix.ipojo.annotations.Requires;
-import org.geotools.referencing.CRS;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.threeten.extra.Interval;
-
-import javax.measure.unit.NonSI;
-import javax.measure.unit.SI;
-import javax.measure.unit.Unit;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -64,11 +55,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.DATETIME_INTERVAL_SEPARATOR;
-import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_BBOX;
-import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_DATETIME;
-import static de.ii.ldproxy.ogcapi.features.core.domain.FeaturesCoreConfiguration.PARAMETER_Q;
+import javax.measure.unit.NonSI;
+import javax.measure.unit.SI;
+import javax.measure.unit.Unit;
+import org.apache.felix.ipojo.annotations.Component;
+import org.apache.felix.ipojo.annotations.Instantiate;
+import org.apache.felix.ipojo.annotations.Provides;
+import org.apache.felix.ipojo.annotations.Requires;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.threeten.extra.Interval;
 
 
 @Component
@@ -428,13 +424,12 @@ public class FeaturesQueryImpl implements FeaturesQuery {
         // check, if we need to add a precision value; for this we need the target CRS,
         // so we need to build the query to get the CRS
         ImmutableFeatureQuery query = queryBuilder.build();
-        if (!coreConfiguration.getCoordinatePrecision().isEmpty()) {
+        if (!coreConfiguration.getCoordinatePrecision().isEmpty() && query.getCrs().isPresent()) {
             Integer precision = null;
             // TODO we need to handle different units per axis, right now we just look at the first axis
             //      and assume that the vertical precision would be less digits than the horizontal one
             try {
-                CoordinateReferenceSystem gtCrs = CRS.decode("EPSG:"+query.getCrs().get().getCode());
-                Unit<?> unit = gtCrs.getCoordinateSystem().getAxis(0).getUnit();
+                Unit<?> unit = crsTransformerFactory.getCrsUnit(query.getCrs().get());
                 if (unit.equals(SI.METRE)) {
                     precision = coreConfiguration.getCoordinatePrecision().get("meter");
                     if (Objects.isNull(precision))
@@ -446,8 +441,8 @@ public class FeaturesQueryImpl implements FeaturesQuery {
                 }
                 if (Objects.nonNull(precision))
                     queryBuilder.geometryPrecision(precision);
-            } catch (FactoryException e) {
-                LOGGER.debug("Coordinate precision could not be set, could not retrieve coordinate reference system 'EPSG:{}'.", query.getCrs().get().getCode());
+            } catch (Throwable e) {
+                LOGGER.debug("Coordinate precision could not be set: {}'.", e.getMessage());
             }
         }
         return queryBuilder;

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
@@ -75,6 +75,8 @@ public interface FeaturesCoreConfiguration extends ExtensionConfiguration, Featu
 
     Optional<FeaturesCollectionQueryables> getQueryables();
 
+    Map<String, Integer> getCoordinatePrecision();
+
     @Override
     Map<String, FeatureTypeMapping2> getTransformations();
 
@@ -227,4 +229,17 @@ public interface FeaturesCoreConfiguration extends ExtensionConfiguration, Featu
         return new ImmutableFeaturesCoreConfiguration.Builder();
     }
 
+    @Override
+    default ExtensionConfiguration mergeInto(ExtensionConfiguration source) {
+        ImmutableFeaturesCoreConfiguration.Builder builder = ((ImmutableFeaturesCoreConfiguration.Builder) source.getBuilder())
+                .from(source)
+                .from(this);
+
+        //TODO: this is a work-around for default from behaviour (map is not reset, which leads to duplicates in ImmutableMap)
+        // try to find a better solution that also enables deep merges
+        if (!getCoordinatePrecision().isEmpty())
+            builder.coordinatePrecision(getCoordinatePrecision());
+
+        return builder.build();
+    }
 }


### PR DESCRIPTION
This PR starts to address #399. It adds the capability to specify the number of maximum number decimal digits in coordinates depending on the unit of the number. The default is still that no digits are cut. 

Example: 

```yaml
- buildingBlock: FEATURES_CORE
  coordinatePrecision:
    metre: 2
    degree: 7
``` 

Open issues:

- There can be different units in a CRS (in particular - horizontal is degrees, vertical is meters). Currently there is only one precision value for all axes.
- The HTML Filter editor also creates coordinates for the `bbox` parameter that have some 15 decimal places or so. Since this one is always in degrees and just a rough filter, maybe always restrict this to 4 decimal places (approx 11 meters) or so?
- Currently only meter and degree are supported as units. For the typical cases, this should be sufficient, at least for now. So maybe that is not something we need to address now.
