### PR TITLE
gpkg

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-application' version '3.4.0'
+    id 'de.interactive_instruments.xtraplatform-application' version '3.5.0'
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.github.hierynomus.license-report' version '0.15.0' apply false
     id 'com.bmuschko.docker-java-application' version '3.1.0' apply false

--- a/composite/build.gradle
+++ b/composite/build.gradle
@@ -1,9 +1,8 @@
-task run {
-    dependsOn gradle.includedBuild('ldproxy').task(':run')
+plugins {
+    id 'de.interactive_instruments.xtraplatform-composite' version '3.5.0'
 }
-task check {
-    dependsOn gradle.includedBuild('ldproxy').task(':check')
-}
+
+
 task manager {
     dependsOn gradle.includedBuild('ldproxy').task(':ldproxy-manager:assemble')
 }

--- a/composite/settings.gradle
+++ b/composite/settings.gradle
@@ -1,11 +1,29 @@
+pluginManagement {
+    repositories {
+        maven {
+            url 'https://dl.bintray.com/iide/maven'
+        }
+        maven {
+            url "https://dl.interactive-instruments.de/repository/maven-releases/"
+        }
+        maven {
+            url "https://dl.interactive-instruments.de/repository/maven-snapshots/"
+        }
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'ldproxy-composite'
 
 def siblingDirectories = rootDir.parentFile.parentFile.listFiles()
 def xtraplatform = siblingDirectories.find({ it.name.toLowerCase().equals('xtraplatform') })
 def xtraplatformSpatial = siblingDirectories.find({ it.name.toLowerCase().equals('xtraplatform-spatial') })
+def xtraplatformBuild = siblingDirectories.find({ it.name.toLowerCase().equals('xtraplatform-build') })
 
+if (xtraplatformBuild) {
+    includeBuild "../../${xtraplatformBuild.name}"
+}
 if (xtraplatform) {
-    includeBuild "../../${xtraplatform.name}/xtraplatform-gradle-plugins"
     includeBuild "../../${xtraplatform.name}/xtraplatform-core"
     includeBuild "../../${xtraplatform.name}/xtraplatform-dev"
 }

--- a/docs/de/configuration/providers/sql.md
+++ b/docs/de/configuration/providers/sql.md
@@ -6,17 +6,16 @@ Hier werden die Besonderheiten des SQL-Feature-Providers beschrieben.
 
 ## Das Connection-Info-Objekt für SQL-Datenbanken
 
-Das Connection-Info-Objekt für PostgreSQL/PostGIS-Datenbanken wird wie folgt beschrieben:
+Das Connection-Info-Objekt für SQL-Datenbanken wird wie folgt beschrieben:
 
 |Eigenschaft |Datentyp |Default |Beschreibung
 | --- | --- | --- | ---
-|`connectorType` |enum | |Stets `SLICK`.
-|`dialect` |enum | |Stets `PGIS`.
-|`host` |string | |Der Datenbankhost. Wird ein anderer Port als der Standardport verwendet, ist dieser durch einen Doppelpunkt getrennt anzugeben, z.B. `db:30305`.
-|`database` |string | |Der Name der Datenbank.
-|`schemas` |array |`[ 'public' ]` |Die Namen der Schemas in der Datenbank, auf die zugegriffen werden soll.
-|`user` |string | |Der Benutzername.
-|`password` |string | |Das mit base64 kodierte Passwort des Benutzers.
+|`dialect` |enum | |`PGIS` für PostgreSQL/PostGIS, `GPKG` für GeoPackages oder SQLite/SpatiaLite.
+|`host` |string | |Der Datenbankhost. Wird ein anderer Port als der Standardport verwendet, ist dieser durch einen Doppelpunkt getrennt anzugeben, z.B. `db:30305`. Nicht relevant für `GPKG`. 
+|`database` |string | |Der Name der Datenbank. Für `GPKG` der Pfad zur Datei, entweder absolut oder relativ zum [Daten-Verzeichnis](../../data-folder.md).
+|`schemas` |array |`[ 'public' ]` |Die Namen der Schemas in der Datenbank, auf die zugegriffen werden soll. Nicht relevant für `GPKG`. 
+|`user` |string | |Der Benutzername. Nicht relevant für `GPKG`. 
+|`password` |string | |Das mit base64 kodierte Passwort des Benutzers. Nicht relevant für `GPKG`. 
 |`initFailFast` |boolean |`true` |Steuert, ob das Starten des Feature-Providers abgebrochen werden soll, wenn der Verbindungsaufbau etwas länger dauert. Diese Option sollte in der Regel nur auf Entwicklungssystemen deaktiviert werden.
 |`maxConnections` |integer |dynamisch |Steuert die maximale Anzahl von Verbindungen zur Datenbank. Der Default-Wert ist abhängig von der Anzahl der Prozessorkerne und der Anzahl der Joins in der [Types-Konfiguration](README.md#feature-provider-types). Der Default-Wert wird für optimale Performanz unter Last empfohlen. Der kleinstmögliche Wert ist ebenfalls von der Anzahl der Joins abhängig, kleinere Werte werden zurückgewiesen. 
 |`minConnections` |integer |`maxConnections` |Steuert die minimale Anzahl von Verbindungen zur Datenbank, die jederzeit offen gehalten werden.

--- a/ogcapi-draft/build.gradle
+++ b/ogcapi-draft/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-feature' version '3.4.0'
+    id 'de.interactive_instruments.xtraplatform-feature' version '3.5.0'
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.github.hierynomus.license-report' version '0.15.0' apply false
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/FeatureTransformerTilesMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/FeatureTransformerTilesMVT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 interactive instruments GmbH
+ * Copyright 2021 interactive instruments GmbH
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -895,11 +895,12 @@ public class FeatureTransformerTilesMVT extends FeatureTransformerBase {
 
     private CoordinateSequence parseCoordinates(String text) {
         double[] coords = ArrayUtils.toPrimitive(
-                Splitter.on(separatorPattern)
-                        .splitToList(text)
-                        .stream()
-                        .map(num -> Double.parseDouble(num))
-                        .toArray(Double[]::new));
+            Splitter.on(separatorPattern)
+                .omitEmptyStrings()
+                .splitToList(text)
+                .stream()
+                .map(num -> Double.parseDouble(num))
+                .toArray(Double[]::new));
         if (crsTransformer!=null) {
             if (currentDimension == 2) {
                 coords = crsTransformer.transform(coords, coords.length / currentDimension, swapCoordinates);

--- a/ogcapi-draft/settings.gradle
+++ b/ogcapi-draft/settings.gradle
@@ -3,6 +3,12 @@ pluginManagement {
         maven {
             url 'https://dl.bintray.com/iide/maven'
         }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-releases/"  
+        }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-snapshots/"  
+        }
         gradlePluginPortal()
     }
 }

--- a/ogcapi-stable/build.gradle
+++ b/ogcapi-stable/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-feature' version '3.4.0'
+    id 'de.interactive_instruments.xtraplatform-feature' version '3.5.0'
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.github.hierynomus.license-report' version '0.15.0' apply false
 }

--- a/ogcapi-stable/settings.gradle
+++ b/ogcapi-stable/settings.gradle
@@ -3,6 +3,12 @@ pluginManagement {
         maven {
             url 'https://dl.bintray.com/iide/maven'
         }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-releases/"  
+        }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-snapshots/"  
+        }
         gradlePluginPortal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,12 @@ pluginManagement {
         maven {
             url 'https://dl.bintray.com/iide/maven'
         }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-releases/"  
+        }
+        maven {  
+            url "https://dl.interactive-instruments.de/repository/maven-snapshots/"  
+        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Closes interactive-instruments/ldproxy-project-management#102.

Sample configuration: https://gitea.ci.interactive-instruments.de/ldproxy/gpkg
Sample deployment: https://gpkg.ldproxy.net

@cportele 
- This will not work out of the box in your dev env as `libspatialite` for macOS is not included. It should work if you install it as a system library (`brew install sqlite3 libspatialite`).
- I enabled [git-lfs](https://git-lfs.github.com) in Gitea and used it for the `gpkg` file in the repo. This means you need to install [git-lfs](https://git-lfs.github.com) locally if you do not already have it to be able to clone the repo including the `gpkg` file. We should then use git-lfs for all data dumps in the repos from now on.