### PR TITLE
support caching headers / conditional GET requests

### DIFF
--- a/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/app/EndpointQueryables.java
+++ b/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/app/EndpointQueryables.java
@@ -121,13 +121,9 @@ public class EndpointQueryables extends EndpointSubCollection /* implements Conf
                              @Context UriInfo uriInfo,
                              @PathParam("collectionId") String collectionId) {
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
-
         QueryablesQueriesHandlerImpl.QueryInputQueryables queryInput = new ImmutableQueryInputQueryables.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueryablesQueriesHandlerImpl.Query.QUERYABLES, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/domain/QueryablesConfiguration.java
+++ b/ogcapi-draft/ogcapi-collections-queryables/src/main/java/de/ii/ldproxy/ogcapi/collections/queryables/domain/QueryablesConfiguration.java
@@ -8,13 +8,14 @@
 package de.ii.ldproxy.ogcapi.collections.queryables.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableQueryablesConfiguration.Builder.class)
-public interface QueryablesConfiguration extends ExtensionConfiguration {
+public interface QueryablesConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/EndpointSchema.java
+++ b/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/EndpointSchema.java
@@ -115,15 +115,11 @@ public class EndpointSchema extends EndpointSubCollection {
                              @Context UriInfo uriInfo,
                              @PathParam("collectionId") String collectionId) {
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
-
         Optional<String> profile = Optional.ofNullable(requestContext.getParameters().get("profile"));
 
         QueriesHandlerSchemaImpl.QueryInputSchema queryInput = new ImmutableQueryInputSchema.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
-                .includeLinkHeader(includeLinkHeader)
                 .profile(profile)
                 .build();
 

--- a/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/QueriesHandlerSchemaImpl.java
+++ b/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/QueriesHandlerSchemaImpl.java
@@ -22,6 +22,7 @@ import de.ii.ldproxy.ogcapi.domain.QueryInput;
 import de.ii.ldproxy.ogcapi.features.core.domain.SchemaGeneratorFeature;
 import de.ii.ldproxy.ogcapi.features.geojson.domain.FeatureTransformerGeoJson;
 import de.ii.ldproxy.ogcapi.features.geojson.domain.GeoJsonConfiguration;
+import de.ii.ldproxy.ogcapi.features.geojson.domain.JsonSchema;
 import de.ii.ldproxy.ogcapi.features.geojson.domain.JsonSchemaObject;
 import de.ii.ldproxy.ogcapi.features.geojson.domain.SchemaGeneratorGeoJson;
 import org.apache.felix.ipojo.annotations.Component;
@@ -32,10 +33,13 @@ import org.immutables.value.Value;
 
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import java.text.MessageFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -111,7 +115,16 @@ public class QueriesHandlerSchemaImpl implements QueriesHandlerSchema {
                                                                                                        .map(link -> link.getHref())
                                                                                                        .findAny(), type, getVersion(queryInput.getProfile()));
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = getLastModified(queryInput, api);
+        EntityTag etag = getEtag(jsonSchema, JsonSchema.FUNNEL, outputFormat);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(outputFormat.getEntity(jsonSchema, collectionId, api, requestContext))
                 .build();
     }

--- a/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/SchemaConfiguration.java
+++ b/ogcapi-draft/ogcapi-collections-schema/src/main/java/de/ii/ldproxy/ogcapi/collections/schema/SchemaConfiguration.java
@@ -8,13 +8,14 @@
 package de.ii.ldproxy.ogcapi.collections.schema;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableSchemaConfiguration.Builder.class)
-public interface SchemaConfiguration extends ExtensionConfiguration {
+public interface SchemaConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/QueriesHandlerResourcesImpl.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/QueriesHandlerResourcesImpl.java
@@ -36,6 +36,7 @@ import org.osgi.framework.BundleContext;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
@@ -43,9 +44,13 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -121,7 +126,22 @@ public class QueriesHandlerResourcesImpl implements QueriesHandlerResources {
                                                            .map(ResourcesFormatExtension.class::cast)
                                                            .orElseThrow(() -> new NotAcceptableException(MessageFormat.format("The requested media type {0} cannot be generated.", requestContext.getMediaType().type())));
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? resources.getLinks() : null)
+        Date lastModified = Arrays.stream(apiDir.listFiles())
+                                  .filter(file -> !file.isHidden())
+                                  .map(File::lastModified)
+                                  .max(Comparator.naturalOrder())
+                                  .map(Instant::ofEpochMilli)
+                                  .map(Date::from)
+                                  .orElse(Date.from(Instant.now()));
+        EntityTag etag = getEtag(resources, Resources.FUNNEL, format);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? resources.getLinks() : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(format.getResourcesEntity(resources, apiData, requestContext))
                 .build();
     }
@@ -164,7 +184,16 @@ public class QueriesHandlerResourcesImpl implements QueriesHandlerResources {
         if (contentType==null || contentType.isEmpty())
             contentType = "application/octet-stream";
 
-        return prepareSuccessResponse(api, requestContext, null)
+        Date lastModified = getLastModified(resourceFile.toFile());
+        EntityTag etag = getEtag(resource);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(format.getResourceEntity(resource, resourceId, apiData, requestContext))
                 .type(contentType)
                 .header("Content-Disposition", "inline; filename=\""+resourceId+"\"")

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/Resource.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/Resource.java
@@ -9,8 +9,15 @@ package de.ii.ldproxy.resources.app;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
+import de.ii.ldproxy.ogcapi.styles.domain.StylesheetMetadata;
 import org.immutables.value.Value;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Objects;
 
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true)
@@ -21,4 +28,11 @@ public abstract class Resource {
     public abstract String getId();
 
     public abstract Link getLink();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<Resource> FUNNEL = (from, into) -> {
+        into.putString(from.getId(), StandardCharsets.UTF_8);
+        into.putString(from.getLink().getHref(), StandardCharsets.UTF_8)
+            .putString(Objects.requireNonNullElse(from.getLink().getRel(), ""), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/Resources.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/app/Resources.java
@@ -9,18 +9,31 @@ package de.ii.ldproxy.resources.app;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
+import de.ii.ldproxy.ogcapi.styles.domain.StyleEntry;
+import de.ii.ldproxy.ogcapi.styles.domain.Styles;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(as = ImmutableResources.class)
-public abstract class Resources {
+public abstract class Resources extends PageRepresentation {
 
     public abstract List<Resource> getResources();
 
-    public abstract List<Link> getLinks();
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<Resources> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getResources()
+            .stream()
+            .sorted(Comparator.comparing(Resource::getId))
+            .forEachOrdered(val -> Resource.FUNNEL.funnel(val, into));
+    };
 }

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/domain/ResourcesConfiguration.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/domain/ResourcesConfiguration.java
@@ -8,6 +8,7 @@
 package de.ii.ldproxy.resources.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import org.immutables.value.Value;
 
@@ -16,7 +17,7 @@ import javax.annotation.Nullable;
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableResourcesConfiguration.Builder.class)
-public interface ResourcesConfiguration extends ExtensionConfiguration {
+public interface ResourcesConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/infra/EndpointResource.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/infra/EndpointResource.java
@@ -135,6 +135,7 @@ public class EndpointResource extends Endpoint {
     public Response getResource(@PathParam("resourceId") String resourceId, @Context OgcApi api,
                                 @Context ApiRequestContext requestContext) {
         QueriesHandlerResources.QueryInputResource queryInput = ImmutableQueryInputResource.builder()
+                                                                                           .from(getGenericQueryInput(api.getData()))
                                                                                            .resourceId(resourceId)
                                                                                            .build();
 

--- a/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/infra/EndpointResources.java
+++ b/ogcapi-draft/ogcapi-resources/src/main/java/de/ii/ldproxy/resources/infra/EndpointResources.java
@@ -132,11 +132,8 @@ public class EndpointResources extends Endpoint {
     @Produces({MediaType.APPLICATION_JSON,MediaType.TEXT_HTML})
     public Response getResources(@Context OgcApi api, @Context ApiRequestContext requestContext) {
         OgcApiDataV2 apiData = api.getData();
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerResources.QueryInputResources queryInput = ImmutableQueryInputResources.builder()
-                                                                                             .includeLinkHeader(includeLinkHeader)
+                                                                                             .from(getGenericQueryInput(api.getData()))
                                                                                              .build();
 
         return queryHandler.handle(QueriesHandlerResources.Query.RESOURCES, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/QueriesHandlerStylesImpl.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/QueriesHandlerStylesImpl.java
@@ -32,10 +32,14 @@ import org.apache.felix.ipojo.annotations.Provides;
 import org.apache.felix.ipojo.annotations.Requires;
 
 import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import java.text.MessageFormat;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -80,7 +84,18 @@ public class QueriesHandlerStylesImpl implements QueriesHandlerStyles {
                                                                                    requestContext.getMediaType(),
                                                                                    String.join(", ", styleRepository.getStylesFormatStream(apiData, collectionId).map(f -> f.getMediaType().type().toString()).collect(Collectors.toUnmodifiableList())))));
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? styles.getLinks() : null)
+        Date lastModified = styles.getLastModified()
+                                  .orElse(Date.from(Instant.now()));
+        EntityTag etag = getEtag(styles, Styles.FUNNEL, format);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext,
+                                      queryInput.getIncludeLinkHeader() ? styles.getLinks() : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(format.getStylesEntity(styles, apiData, collectionId, requestContext))
                 .build();
     }
@@ -103,14 +118,22 @@ public class QueriesHandlerStylesImpl implements QueriesHandlerStyles {
 
         // collect self/alternate links, but only, if we need to return them in the headers
         List<Link> links = null;
-        boolean includeLinkHeader = queryInput.getIncludeLinkHeader();
-        if (includeLinkHeader) {
+        if (queryInput.getIncludeLinkHeader()) {
             final DefaultLinksGenerator defaultLinkGenerator = new DefaultLinksGenerator();
             List<ApiMediaType> alternateMediaTypes = styleRepository.getStylesheetMediaTypes(apiData, collectionId, styleId);
             links = defaultLinkGenerator.generateLinks(requestContext.getUriCustomizer(), format.getMediaType(), alternateMediaTypes, i18n, requestContext.getLanguage());
         }
 
-        return prepareSuccessResponse(api, requestContext, links)
+        Date lastModified = styleRepository.getStylesheetLastModified(apiData, collectionId, styleId, format, true);
+        EntityTag etag = getEtag(stylesheetContent.getContent());
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, links,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(format.getStyleEntity(stylesheetContent, apiData, collectionId, styleId, requestContext))
                 .header("Content-Disposition", "inline; filename=\""+styleId+"."+format.getFileExtension()+"\"")
                 .build();
@@ -130,7 +153,16 @@ public class QueriesHandlerStylesImpl implements QueriesHandlerStyles {
                                                                                           requestContext.getMediaType(),
                                                                                           String.join(", ", styleRepository.getStyleMetadataFormatStream(apiData, collectionId).map(f -> f.getMediaType().type().toString()).collect(Collectors.toUnmodifiableList())))));
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? metadata.getLinks() : null)
+        Date lastModified = styleRepository.getStyleLastModified(apiData, collectionId, queryInput.getStyleId());
+        EntityTag etag = getEtag(metadata, StyleMetadata.FUNNEL, format);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? metadata.getLinks() : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(format.getStyleMetadataEntity(metadata, apiData, collectionId, requestContext))
                 .build();
     }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/StyleView.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/app/StyleView.java
@@ -38,11 +38,11 @@ public class StyleView extends GenericView {
         this.popup = popup;
         this.layerSwitcher = layerControl;
         this.layerIds = "{" +
-                String.join(", ", layerMap.entrySet()
-                                          .stream()
-                                          .sorted(Comparator.comparing(Map.Entry::getKey))
-                                          .map(entry -> "\""+entry.getKey()+"\": [ \"" + String.join("\", \"", entry.getValue()) + "\" ]")
-                                          .collect(Collectors.toList())) +
+                layerMap.entrySet()
+                        .stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(entry -> "\""+entry.getKey()+"\": [ \"" + String.join("\", \"", entry.getValue()) + "\" ]")
+                        .collect(Collectors.joining(", ")) +
                 "}";
 
         Optional<BoundingBox> spatialExtent = apiData.getSpatialExtent();

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleEntry.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleEntry.java
@@ -9,10 +9,13 @@ package de.ii.ldproxy.ogcapi.styles.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentationWithId;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,4 +32,7 @@ public abstract class StyleEntry extends PageRepresentationWithId {
                          .sorted(Comparator.comparing(Link::getTitle))
                          .collect(Collectors.toList());
     }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<StyleEntry> FUNNEL = PageRepresentationWithId.FUNNEL::funnel;
 }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleLayer.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleLayer.java
@@ -9,10 +9,16 @@ package de.ii.ldproxy.ogcapi.styles.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
+import de.ii.ldproxy.ogcapi.features.geojson.domain.JsonSchema;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,7 +34,7 @@ public abstract class StyleLayer {
 
     public abstract Optional<String> getType();
 
-    public abstract Map<String, Object> getAttributes();
+    public abstract Map<String, JsonSchema> getAttributes();
 
     public abstract Optional<Link> getSampleData();
 
@@ -37,4 +43,18 @@ public abstract class StyleLayer {
     public Optional<String> getAttributeList() {
         return getAttributes().isEmpty() ? Optional.empty() : Optional.of(String.join(", ", getAttributes().keySet().stream().sorted().collect(Collectors.toUnmodifiableList())));
     }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<StyleLayer> FUNNEL = (from, into) -> {
+        into.putString(from.getId(), StandardCharsets.UTF_8);
+        from.getDescription().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getType().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getAttributes()
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEachOrdered(entry -> JsonSchema.FUNNEL.funnel(entry.getValue(), into));
+        from.getSampleData().ifPresent(link -> into.putString(link.getHref(), StandardCharsets.UTF_8)
+                                                   .putString(Objects.requireNonNullElse(link.getRel(), ""), StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleRepository.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StyleRepository.java
@@ -14,6 +14,7 @@ import de.ii.ldproxy.ogcapi.domain.OgcApiDataV2;
 import de.ii.xtraplatform.store.domain.entities.ImmutableValidationResult;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -93,6 +94,28 @@ public interface StyleRepository {
      * @return {@code true}, if the stylesheet exists
      */
     boolean stylesheetExists(OgcApiDataV2 apiData, Optional<String> collectionId, String styleId, StyleFormatExtension styleFormat, boolean includeDerived);
+
+    /**
+     * determine date of last change to any stylesheet of the style; this includes root stylesheets from
+     * which a collection stylesheet will be derived
+     * @param apiData information about the API
+     * @param collectionId the optional collection, or empty for a style collection at root level
+     * @param styleId the identifier of the style in the style collection
+     * @return the date or {@code null}, if no stylesheet is found
+     */
+    Date getStyleLastModified(OgcApiDataV2 apiData, Optional<String> collectionId, String styleId);
+
+    /**
+     * determine date of last change to a stylesheet of the style; this includes root stylesheets from
+     * which a collection stylesheet will be derived
+     * @param apiData information about the API
+     * @param collectionId the optional collection, or empty for a style collection at root level
+     * @param styleId the identifier of the style in the style collection
+     * @param styleFormat the style encoding
+     * @param includeDerived controls, if styles/stylesheets are included that are derived on-the-fly
+     * @return the date or {@code null}, if no stylesheet is found
+     */
+    Date getStylesheetLastModified(OgcApiDataV2 apiData, Optional<String> collectionId, String styleId, StyleFormatExtension styleFormat, boolean includeDerived);
 
     /**
      * fetches a stylesheet

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/Styles.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/Styles.java
@@ -9,9 +9,12 @@ package de.ii.ldproxy.ogcapi.styles.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -24,4 +27,19 @@ public abstract class Styles extends PageRepresentation {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<Styles> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getStyles()
+            .stream()
+            .sorted(Comparator.comparing(StyleEntry::getId))
+            .forEachOrdered(val -> StyleEntry.FUNNEL.funnel(val, into));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
 }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StylesConfiguration.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StylesConfiguration.java
@@ -9,6 +9,7 @@ package de.ii.ldproxy.ogcapi.styles.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Lists;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import org.immutables.value.Value;
 
@@ -18,7 +19,7 @@ import java.util.List;
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableStylesConfiguration.Builder.class)
-public interface StylesConfiguration extends ExtensionConfiguration {
+public interface StylesConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StylesheetMetadata.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/domain/StylesheetMetadata.java
@@ -10,10 +10,15 @@ package de.ii.ldproxy.ogcapi.styles.domain;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 
 @Value.Immutable
@@ -33,4 +38,16 @@ public abstract class StylesheetMetadata {
     public abstract Optional<String> getTileMatrixSet();
 
     public abstract Optional<Link> getLink();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<StylesheetMetadata> FUNNEL = (from, into) -> {
+        from.getTitle().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getVersion().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getSpecification().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.native_().ifPresent(into::putBoolean);
+        from.getTileMatrixSet().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getLink().ifPresent(link -> into.putString(link.getHref(), StandardCharsets.UTF_8)
+                                             .putString(Objects.requireNonNullElse(link.getRel(), ""), StandardCharsets.UTF_8));
+    };
+
 }

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyle.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyle.java
@@ -158,12 +158,9 @@ public class EndpointStyle extends Endpoint {
         OgcApiDataV2 apiData = api.getData();
         checkPathParameter(extensionRegistry, apiData, "/collections/{collectionId}/styles/{styleId}", "styleId", styleId);
 
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyle queryInput = new ImmutableQueryInputStyle.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .styleId(styleId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLE, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleCollection.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleCollection.java
@@ -159,13 +159,10 @@ public class EndpointStyleCollection extends EndpointSubCollection {
         checkPathParameter(extensionRegistry, apiData, "/collections/{collectionId}/styles/{styleId}", "styleId", styleId);
         checkCollectionExists(apiData, collectionId);
 
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyle queryInput = new ImmutableQueryInputStyle.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
                 .styleId(styleId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLE, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleMetadata.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleMetadata.java
@@ -120,12 +120,9 @@ public class EndpointStyleMetadata extends Endpoint {
         OgcApiDataV2 apiData = api.getData();
         checkPathParameter(extensionRegistry, apiData, "/collections/{collectionId}/styles/{styleId}/metadata", "styleId", styleId);
 
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyle queryInput = new ImmutableQueryInputStyle.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .styleId(styleId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLE_METADATA, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleMetadataCollection.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyleMetadataCollection.java
@@ -135,13 +135,10 @@ public class EndpointStyleMetadataCollection extends EndpointSubCollection {
         checkPathParameter(extensionRegistry, apiData, "/collections/{collectionId}/styles/{styleId}/metadata", "styleId", styleId);
         checkCollectionExists(apiData, collectionId);
 
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyle queryInput = new ImmutableQueryInputStyle.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
                 .styleId(styleId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLE_METADATA, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyles.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStyles.java
@@ -92,12 +92,8 @@ public class EndpointStyles extends Endpoint implements ConformanceClass {
     @GET
     @Produces({MediaType.APPLICATION_JSON,MediaType.TEXT_HTML})
     public Response getStyles(@Context OgcApi api, @Context ApiRequestContext requestContext) {
-        OgcApiDataV2 apiData = api.getData();
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyles queryInput = new ImmutableQueryInputStyles.Builder()
-                .includeLinkHeader(includeLinkHeader)
+                .from(getGenericQueryInput(api.getData()))
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLES, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStylesCollection.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ldproxy/ogcapi/styles/infra/EndpointStylesCollection.java
@@ -134,12 +134,9 @@ public class EndpointStylesCollection extends EndpointSubCollection implements C
         checkPathParameter(extensionRegistry, apiData, "/collections/{collectionId}/styles", "collectionId", collectionId);
         checkCollectionExists(apiData, collectionId);
 
-        boolean includeLinkHeader = apiData.getExtension(FoundationConfiguration.class)
-                                           .map(FoundationConfiguration::getIncludeLinkHeader)
-                                           .orElse(false);
         QueriesHandlerStyles.QueryInputStyles queryInput = new ImmutableQueryInputStyles.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(QueriesHandlerStyles.Query.STYLES, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TileFormatMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TileFormatMVT.java
@@ -325,7 +325,7 @@ public class TileFormatMVT implements TileFormatExtension {
      *
      * @param tile            the tile
      */
-    public Object getEmptyTile(Tile tile) {
+    public byte[] getEmptyTile(Tile tile) {
         return new VectorTileEncoder(tile.getTileMatrixSet().getTileExtent()).encode();
     }
 

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
+import de.ii.ldproxy.ogcapi.common.domain.ConformanceDeclaration;
 import de.ii.ldproxy.ogcapi.domain.ApiMediaType;
 import de.ii.ldproxy.ogcapi.domain.ApiRequestContext;
 import de.ii.ldproxy.ogcapi.domain.DefaultLinksGenerator;
@@ -46,6 +47,7 @@ import de.ii.ldproxy.ogcapi.tiles.domain.TileFormatExtension;
 import de.ii.ldproxy.ogcapi.tiles.domain.TileLayer;
 import de.ii.ldproxy.ogcapi.tiles.domain.TileSet;
 import de.ii.ldproxy.ogcapi.tiles.domain.TileSetFormatExtension;
+import de.ii.ldproxy.ogcapi.tiles.domain.TileSets;
 import de.ii.ldproxy.ogcapi.tiles.domain.TileSetsFormatExtension;
 import de.ii.ldproxy.ogcapi.tiles.domain.TilesCache;
 import de.ii.ldproxy.ogcapi.tiles.domain.TilesConfiguration;
@@ -73,16 +75,21 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.AbstractMap;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -222,8 +229,20 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                                                                     requestContext.getUriCustomizer().copy()))
                                        .collect(Collectors.toUnmodifiableList()));
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
-                .entity(outputFormat.getTileSetsEntity(builder.build(), collectionId, api, requestContext))
+        TileSets tileSets = builder.build();
+
+        Date lastModified = getLastModified(queryInput, requestContext.getApi());
+        EntityTag etag = getEtag(tileSets, TileSets.FUNNEL, outputFormat);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
+                .entity(outputFormat.getTileSetsEntity(tileSets, collectionId, api, requestContext))
                 .build();
     }
 
@@ -262,8 +281,20 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                                      zoomLevels, center,
                                      collectionId, links,
                                      requestContext.getUriCustomizer().copy());
-        
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+
+        Date lastModified = getLastModified(queryInput, requestContext.getApi());
+        EntityTag etag = getEtag(tileset, TileSet.FUNNEL, outputFormat);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified,
+                                      etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      null)
                 .entity(outputFormat.getTileSetEntity(tileset, apiData, collectionId, requestContext))
                 .build();
     }
@@ -364,7 +395,8 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                 throw new NotAcceptableException(MessageFormat.format("The requested media type {0} cannot be generated, because it does not support streaming.", requestContext.getMediaType().type()));
             }
 
-            return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+            // internal processing, no need to process headers
+            return prepareSuccessResponse(requestContext.getApi(), requestContext, null)
                     .entity(queryInput.getOutputStream().get())
                     .build();
         }
@@ -384,7 +416,19 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
             throw new NotAcceptableException(MessageFormat.format("The requested media type {0} cannot be generated, because it does not support streaming.", requestContext.getMediaType().type()));
         }
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = Date.from(Instant.now());
+        EntityTag etag = null;
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified,
+                                      etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      null)
                 .entity(streamingOutput)
                 .build();
     }
@@ -540,14 +584,27 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
             }
         }
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = Date.from(Instant.now());
+        EntityTag etag = getEtag(result.byteArray);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified,
+                                      etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      null)
                 .entity(result.byteArray)
                 .build();
     }
 
     private Response getTileFileResponse(QueryInputTileFile queryInput, ApiRequestContext requestContext) {
 
-        StreamingOutput streamingOutput = outputStream -> ByteStreams.copy(new FileInputStream(queryInput.getTileFile().toFile()), outputStream);
+        File tileFile = queryInput.getTileFile().toFile();
+        StreamingOutput streamingOutput = outputStream -> ByteStreams.copy(new FileInputStream(tileFile), outputStream);
 
         List<Link> links = new DefaultLinksGenerator().generateLinks(requestContext.getUriCustomizer(),
                                                                      requestContext.getMediaType(),
@@ -555,7 +612,17 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                                                                      i18n,
                                                                      requestContext.getLanguage());
 
-        return prepareSuccessResponse(requestContext.getApi(), requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = getLastModified(tileFile);
+        EntityTag etag = getEtag(tileFile);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(streamingOutput)
                 .build();
     }
@@ -570,7 +637,19 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                                                                      i18n,
                                                                      requestContext.getLanguage());
 
-        return prepareSuccessResponse(requestContext.getApi(), requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = getLastModified(queryInput.getTileProvider().toFile());
+        EntityTag etag = getEtag(staticTileProviderStore.getTile(queryInput.getTileProvider(), queryInput.getTile()));
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified,
+                                      etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      null)
                 .entity(streamingOutput)
                 .build();
     }
@@ -584,7 +663,20 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                                                                      requestContext.getLanguage());
 
         Tile tile = queryInput.getTile();
-        return prepareSuccessResponse(requestContext.getApi(), requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+
+        Date lastModified = Date.from(Instant.now());
+        EntityTag etag = getEtag(tile.getOutputFormat().getEmptyTile(tile));
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(requestContext.getApi(), requestContext,
+                                      queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified,
+                                      etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      null)
                 .entity(tile.getOutputFormat().getEmptyTile(tile))
                 .build();
     }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/tileMatrixSet/TileMatrixSetsQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/tileMatrixSet/TileMatrixSetsQueriesHandlerImpl.java
@@ -32,11 +32,14 @@ import org.apache.felix.ipojo.annotations.Requires;
 
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -99,7 +102,16 @@ public class TileMatrixSetsQueriesHandlerImpl implements TileMatrixSetsQueriesHa
                                                                .links(links)
                                                                .build();
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = getLastModified(queryInput, api);
+        EntityTag etag = getEtag(tileMatrixSets, TileMatrixSets.FUNNEL, outputFormat);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(outputFormat.getTileMatrixSetsEntity(tileMatrixSets, api, requestContext))
                 .build();
     }
@@ -130,7 +142,16 @@ public class TileMatrixSetsQueriesHandlerImpl implements TileMatrixSetsQueriesHa
                                                                         .links(links)
                                                                         .build();
 
-        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null)
+        Date lastModified = getLastModified(queryInput, api);
+        EntityTag etag = getEtag(tileMatrixSetData, TileMatrixSetData.FUNNEL, outputFormat);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        return prepareSuccessResponse(api, requestContext, queryInput.getIncludeLinkHeader() ? links : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null), null)
                 .entity(outputFormat.getTileMatrixSetEntity(tileMatrixSetData, api, requestContext))
                 .build();
     }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileFormatExtension.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileFormatExtension.java
@@ -59,7 +59,7 @@ public interface TileFormatExtension extends FormatExtension {
 
     String getExtension();
 
-    Object getEmptyTile(Tile tile);
+    byte[] getEmptyTile(Tile tile);
 
     FeatureQuery getQuery(Tile tile,
                           List<OgcApiQueryParameter> allowedParameters,

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileLayer.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileLayer.java
@@ -8,11 +8,17 @@
 package de.ii.ldproxy.ogcapi.tiles.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.Metadata2;
+import de.ii.ldproxy.ogcapi.features.geojson.domain.JsonSchema;
 import de.ii.ldproxy.ogcapi.features.geojson.domain.JsonSchemaObject;
+import de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet.TileMatrixSetData;
+import de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet.TileMatrixSetLimits;
 import de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet.TilesBoundingBox;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.Optional;
 
 @Value.Immutable
@@ -44,4 +50,21 @@ public abstract class TileLayer extends Metadata2 {
     // this is for map tiles, so we do not support this for now
     // public abstract Optional<StyleEntry> getStyle();
 
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileLayer> FUNNEL = (from, into) -> {
+        Metadata2.FUNNEL.funnel(from, into);
+        into.putString(from.getId(), StandardCharsets.UTF_8);
+        into.putString(from.getDataType().toString(), StandardCharsets.UTF_8);
+        from.getFeatureType().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getGeometryType().ifPresent(val -> into.putString(val.toString(), StandardCharsets.UTF_8));
+        from.getTheme().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getMinTileMatrix().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getMaxTileMatrix().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getMinCellSize().ifPresent(into::putDouble);
+        from.getMaxCellSize().ifPresent(into::putDouble);
+        from.getMinScaleDenominator().ifPresent(into::putDouble);
+        from.getMaxScaleDenominator().ifPresent(into::putDouble);
+        from.getBoundingBox().ifPresent(val -> TilesBoundingBox.FUNNEL.funnel(val, into));
+        from.getPropertiesSchema().ifPresent(val -> JsonSchema.FUNNEL.funnel(val, into));
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TilePoint.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TilePoint.java
@@ -8,8 +8,12 @@
 package de.ii.ldproxy.ogcapi.tiles.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet.TilesBoundingBox;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +24,11 @@ public
 interface TilePoint {
     List<Double> getCoordinates();
     Optional<String> getTileMatrix();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TilePoint> FUNNEL = (from, into) -> {
+        from.getCoordinates()
+            .forEach(into::putDouble);
+        from.getTileMatrix().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileSets.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TileSets.java
@@ -9,9 +9,14 @@ package de.ii.ldproxy.ogcapi.tiles.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.collections.domain.Collections;
+import de.ii.ldproxy.ogcapi.collections.domain.OgcApiCollection;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,4 +30,19 @@ public abstract class TileSets extends PageRepresentation {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileSets> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getTilesets()
+            .stream()
+            .sorted(Comparator.comparing(TileSet::getTileMatrixSetId))
+            .forEachOrdered(val -> TileSet.FUNNEL.funnel(val, into));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TilesConfiguration.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/TilesConfiguration.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.ldproxy.ogcapi.features.core.domain.FeatureTransformations;
 import de.ii.ldproxy.ogcapi.features.core.domain.PropertyTransformation;
@@ -28,7 +29,7 @@ import java.util.Objects;
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true, builder = "new")
 @JsonDeserialize(builder = ImmutableTilesConfiguration.Builder.class)
-public interface TilesConfiguration extends ExtensionConfiguration, FeatureTransformations {
+public interface TilesConfiguration extends ExtensionConfiguration, FeatureTransformations, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrix.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrix.java
@@ -9,11 +9,17 @@ package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.Link;
 import org.immutables.value.Value;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Value.Immutable
@@ -46,4 +52,23 @@ public abstract class TileMatrix {
 
     @JsonIgnore
     public abstract int getTileLevel();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileMatrix> FUNNEL = (from, into) -> {
+        into.putString(from.getId(), StandardCharsets.UTF_8);
+        from.getTitle().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getDescription().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getKeywords()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+        into.putLong(from.getTileWidth());
+        into.putLong(from.getTileHeight());
+        into.putLong(from.getMatrixWidth());
+        into.putLong(from.getMatrixHeight());
+        into.putDouble(from.getScaleDenominator().doubleValue());
+        Arrays.stream(from.getPointOfOrigin())
+              .forEachOrdered(val -> into.putDouble(val.doubleValue()));
+        into.putString(from.getCornerOfOrigin(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetData.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetData.java
@@ -10,11 +10,20 @@ package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.collections.domain.OgcApiCollection;
 import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
+import de.ii.ldproxy.ogcapi.domain.MetadataDates;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentationWithId;
 import org.immutables.value.Value;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -23,17 +32,9 @@ import java.util.Optional;
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true)
 @JsonDeserialize(builder = ImmutableTileMatrixSetData.Builder.class)
-public abstract class TileMatrixSetData {
-
-    public abstract String getId();
-
-    public abstract Optional<String> getTitle();
-
-    public abstract Optional<String> getDescription();
+public abstract class TileMatrixSetData extends PageRepresentationWithId {
 
     public abstract List<String> getKeywords();
-
-    public abstract List<Link> getLinks();
 
     public abstract String getCrs();
 
@@ -48,4 +49,29 @@ public abstract class TileMatrixSetData {
     public abstract List<TileMatrix> getTileMatrices();
 
     public abstract List<String> getOrderedAxes();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileMatrixSetData> FUNNEL = (from, into) -> {
+        PageRepresentationWithId.FUNNEL.funnel(from, into);
+        from.getKeywords()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getLinks()
+            .stream()
+            .sorted(Comparator.comparing(Link::getHref))
+            .forEachOrdered(link -> into.putString(link.getHref(), StandardCharsets.UTF_8)
+                                        .putString(Objects.requireNonNullElse(link.getRel(), ""), StandardCharsets.UTF_8));
+        into.putString(from.getCrs(), StandardCharsets.UTF_8);
+        from.getUri().ifPresent(s -> into.putString(s.toString(), StandardCharsets.UTF_8));
+        from.getBoundingBox().ifPresent(val -> TilesBoundingBox.FUNNEL.funnel(val, into));
+        from.getTileMatrices()
+            .stream()
+            .sorted(Comparator.comparing(TileMatrix::getId))
+            .forEachOrdered(val -> TileMatrix.FUNNEL.funnel(val, into));
+        from.getOrderedAxes()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetLimits.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetLimits.java
@@ -8,7 +8,11 @@
 package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.tiles.domain.TilePoint;
 import org.immutables.value.Value;
+
+import java.nio.charset.StandardCharsets;
 
 @Value.Immutable
 @Value.Style(builder = "new")
@@ -19,4 +23,13 @@ public abstract class TileMatrixSetLimits {
     public abstract Integer getMaxTileRow();
     public abstract Integer getMinTileCol();
     public abstract Integer getMaxTileCol();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileMatrixSetLimits> FUNNEL = (from, into) -> {
+        into.putString(from.getTileMatrix(), StandardCharsets.UTF_8);
+        into.putInt(from.getMinTileRow());
+        into.putInt(from.getMaxTileRow());
+        into.putInt(from.getMinTileCol());
+        into.putInt(from.getMaxTileCol());
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetLinks.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSetLinks.java
@@ -8,9 +8,13 @@
 package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentationWithId;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.Optional;
 
 @Value.Immutable
@@ -19,4 +23,10 @@ import java.util.Optional;
 public abstract class TileMatrixSetLinks extends PageRepresentationWithId {
 
     public abstract Optional<String> getTileMatrixSetURI();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileMatrixSetLinks> FUNNEL = (from, into) -> {
+        PageRepresentationWithId.FUNNEL.funnel(from, into);
+        from.getTileMatrixSetURI().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSets.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TileMatrixSets.java
@@ -9,9 +9,14 @@ package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
+import de.ii.ldproxy.ogcapi.tiles.domain.TileSet;
+import de.ii.ldproxy.ogcapi.tiles.domain.TileSets;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -24,4 +29,19 @@ public abstract class TileMatrixSets extends PageRepresentation {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TileMatrixSets> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getTileMatrixSets()
+            .stream()
+            .sorted(Comparator.comparing(TileMatrixSetLinks::getId))
+            .forEachOrdered(val -> TileMatrixSetLinks.FUNNEL.funnel(val, into));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
 }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TilesBoundingBox.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/tileMatrixSet/TilesBoundingBox.java
@@ -9,10 +9,18 @@ package de.ii.ldproxy.ogcapi.tiles.domain.tileMatrixSet;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
+import de.ii.ldproxy.ogcapi.tiles.domain.TileLayer;
+import de.ii.ldproxy.ogcapi.tiles.domain.TilePoint;
+import de.ii.ldproxy.ogcapi.tiles.domain.TileSet;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import org.immutables.value.Value;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 
 @Value.Immutable
@@ -34,4 +42,13 @@ public abstract class TilesBoundingBox {
     @Value.Derived
     @Value.Auxiliary
     public Optional<String> getCrs() { return getCrsEpsg().map(EpsgCrs::toUriString); }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<TilesBoundingBox> FUNNEL = (from, into) -> {
+        Arrays.stream(from.getLowerLeft())
+              .forEachOrdered(val -> into.putDouble(val.doubleValue()));
+        Arrays.stream(from.getUpperRight())
+              .forEachOrdered(val -> into.putDouble(val.doubleValue()));
+        from.getCrs().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/domain/CollectionsConfiguration.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/domain/CollectionsConfiguration.java
@@ -11,18 +11,18 @@ import com.fasterxml.jackson.annotation.JsonMerge;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Lists;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.ldproxy.ogcapi.domain.Link;
 import java.util.List;
 import org.immutables.value.Value;
 
-import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableCollectionsConfiguration.Builder.class)
-public interface CollectionsConfiguration extends ExtensionConfiguration {
+public interface CollectionsConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
 

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/domain/OgcApiCollection.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/domain/OgcApiCollection.java
@@ -9,10 +9,13 @@ package de.ii.ldproxy.ogcapi.collections.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import de.ii.ldproxy.ogcapi.common.domain.OgcApiExtent;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentationWithId;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,4 +38,23 @@ public abstract class OgcApiCollection extends PageRepresentationWithId {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<OgcApiCollection> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getExtent().ifPresent(val -> OgcApiExtent.FUNNEL.funnel(val, into));
+        from.getItemType().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getCrs()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getStorageCrs().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getStorageCrsCoordinateEpoch().ifPresent(val -> into.putFloat(val));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
 }

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollection.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollection.java
@@ -208,18 +208,14 @@ public class EndpointCollection extends EndpointSubCollection {
             throw new NotFoundException(MessageFormat.format("The collection ''{0}'' does not exist in this API.", collectionId));
         }
 
-        boolean includeLinkHeader = api.getData()
-                                       .getExtension(FoundationConfiguration.class)
-                                       .map(FoundationConfiguration::getIncludeLinkHeader)
-                                       .orElse(false);
         List<Link> additionalLinks = api.getData()
                                         .getCollections()
                                         .get(collectionId)
                                         .getAdditionalLinks();
 
         QueriesHandlerCollectionsImpl.QueryInputFeatureCollection queryInput = new ImmutableQueryInputFeatureCollection.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
-                .includeLinkHeader(includeLinkHeader)
                 .additionalLinks(additionalLinks)
                 .build();
 

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollections.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ldproxy/ogcapi/collections/infra/EndpointCollections.java
@@ -136,15 +136,12 @@ public class EndpointCollections extends Endpoint implements ConformanceClass {
     public Response getCollections(@Auth Optional<User> optionalUser, @Context OgcApi api,
                                    @Context ApiRequestContext requestContext) {
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
         List<Link> additionalLinks = api.getData().getExtension(CollectionsConfiguration.class)
                                         .map(CollectionsConfiguration::getAdditionalLinks)
                                         .orElse(ImmutableList.of());
 
         QueriesHandlerCollectionsImpl.QueryInputCollections queryInput = new ImmutableQueryInputCollections.Builder()
-                .includeLinkHeader(includeLinkHeader)
+                .from(getGenericQueryInput(api.getData()))
                 .additionalLinks(additionalLinks)
                 .build();
 

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/app/QueriesHandlerCommonImpl.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/app/QueriesHandlerCommonImpl.java
@@ -217,19 +217,15 @@ public class QueriesHandlerCommonImpl implements QueriesHandlerCommon {
         }
 
         Date lastModified = getLastModified(queryInput, requestContext.getApi());
+        // TODO support ETag
         EntityTag etag = null;
         Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
         if (Objects.nonNull(response))
             return response.build();
 
-        return prepareSuccessResponse(requestContext.getApi(), requestContext, null,
-                                      lastModified, etag,
-                                      queryInput.getCacheControl().orElse(null),
-                                      queryInput.getExpires().orElse(null),
-                                      null)
-                .entity(outputFormatExtension.getApiDefinitionResponse(requestContext.getApi().getData(),
-                                                                       requestContext))
-                .build();
+        // TODO support headers
+        return outputFormatExtension.getApiDefinitionResponse(requestContext.getApi().getData(),
+                                                              requestContext);
     }
 
     private List<LandingPageExtension> getDatasetExtenders() {

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/CommonConfiguration.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/CommonConfiguration.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonMerge;
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Lists;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.ldproxy.ogcapi.domain.Link;
 import java.util.List;
@@ -19,7 +20,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableCommonConfiguration.Builder.class)
-public interface CommonConfiguration extends ExtensionConfiguration {
+public interface CommonConfiguration extends ExtensionConfiguration, CachingConfiguration {
 
   abstract class Builder extends ExtensionConfiguration.Builder {
 

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/ConformanceDeclaration.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/ConformanceDeclaration.java
@@ -9,11 +9,17 @@ package de.ii.ldproxy.ogcapi.common.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.PrimitiveSink;
+import de.ii.ldproxy.ogcapi.domain.Link;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableConformanceDeclaration.Builder.class)
@@ -23,4 +29,19 @@ public abstract class ConformanceDeclaration extends PageRepresentation {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<ConformanceDeclaration> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getConformsTo()
+            .stream()
+            .sorted()
+            .forEachOrdered(uri -> into.putString(uri, StandardCharsets.UTF_8));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/LandingPage.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/LandingPage.java
@@ -9,11 +9,17 @@ package de.ii.ldproxy.ogcapi.common.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.PrimitiveSink;
 import de.ii.ldproxy.ogcapi.domain.ExternalDocumentation;
+import de.ii.ldproxy.ogcapi.domain.Link;
 import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Value.Immutable
@@ -28,4 +34,19 @@ public abstract class LandingPage extends PageRepresentation {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<LandingPage> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getAttribution().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getExtent().ifPresent(val -> OgcApiExtent.FUNNEL.funnel(val, into));
+        from.getExternalDocs().ifPresent(val -> ExternalDocumentation.FUNNEL.funnel(val, into));
+        from.getExtensions()
+            .keySet()
+            .stream()
+            .sorted()
+            .forEachOrdered(key -> into.putString(key, StandardCharsets.UTF_8));
+        // we cannot encode the generic extension object
+    };
+
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtent.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtent.java
@@ -7,6 +7,13 @@
  */
 package de.ii.ldproxy.ogcapi.common.domain;
 
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 
 public class OgcApiExtent {
@@ -62,4 +69,11 @@ public class OgcApiExtent {
     public void setTemporal(OgcApiExtentTemporal temporal) {
         this.temporal = Optional.ofNullable(temporal);
     }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<OgcApiExtent> FUNNEL = (from, into) -> {
+        from.getSpatial().ifPresent(val -> OgcApiExtentSpatial.FUNNEL.funnel(val, into));
+        from.getTemporal().ifPresent(val -> OgcApiExtentTemporal.FUNNEL.funnel(val, into));
+    };
+
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtentSpatial.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtentSpatial.java
@@ -8,8 +8,16 @@
 package de.ii.ldproxy.ogcapi.common.domain;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.Link;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
 
 
 public class OgcApiExtentSpatial {
@@ -47,4 +55,12 @@ public class OgcApiExtentSpatial {
     public void setCrs(String crs) {
         this.crs = crs;
     }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<OgcApiExtentSpatial> FUNNEL = (from, into) -> {
+        into.putString(from.getCrs(), StandardCharsets.UTF_8);
+        Arrays.stream(from.getBbox())
+              .forEachOrdered(arr -> Arrays.stream(arr)
+                                           .forEachOrdered(val -> into.putDouble(val)));
+    };
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtentTemporal.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/OgcApiExtentTemporal.java
@@ -8,9 +8,12 @@
 package de.ii.ldproxy.ogcapi.common.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.hash.Funnel;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class OgcApiExtentTemporal {
@@ -53,4 +56,12 @@ public class OgcApiExtentTemporal {
     public void setTrs(String trs) {
         this.trs = trs;
     }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<OgcApiExtentTemporal> FUNNEL = (from, into) -> {
+        into.putString(from.getTrs(), StandardCharsets.UTF_8);
+        Arrays.stream(from.getInterval())
+              .forEachOrdered(arr -> Arrays.stream(arr)
+                                           .forEachOrdered(val -> into.putString(Objects.requireNonNullElse(val, ".."), StandardCharsets.UTF_8)));
+    };
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/QueriesHandlerCommon.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/domain/QueriesHandlerCommon.java
@@ -5,11 +5,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package de.ii.ldproxy.ogcapi.domain;
+package de.ii.ldproxy.ogcapi.common.domain;
 
-import org.immutables.value.Value;
+import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl;
+import de.ii.ldproxy.ogcapi.domain.QueriesHandler;
 
-@Value.Immutable
-public abstract class QueryInputGeneric implements QueryInput {
-
+public interface QueriesHandlerCommon extends QueriesHandler<QueriesHandlerCommonImpl.Query> {
 }

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointConformance.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointConformance.java
@@ -9,7 +9,7 @@ package de.ii.ldproxy.ogcapi.common.infra;
 
 import com.google.common.collect.ImmutableList;
 import de.ii.ldproxy.ogcapi.common.app.ImmutableQueryInputConformance;
-import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommon;
+import de.ii.ldproxy.ogcapi.common.domain.QueriesHandlerCommon;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl.Query;
 import de.ii.ldproxy.ogcapi.common.domain.CommonConfiguration;
@@ -87,12 +87,8 @@ public class EndpointConformance extends Endpoint {
     public Response getConformanceClasses(@Auth Optional<User> optionalUser, @Context OgcApi api,
                                           @Context ApiRequestContext requestContext) {
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
-
         QueriesHandlerCommonImpl.QueryInputConformance queryInput = new ImmutableQueryInputConformance.Builder()
-                .includeLinkHeader(includeLinkHeader)
+                .from(getGenericQueryInput(api.getData()))
                 .build();
 
         return queryHandler.handle(Query.CONFORMANCE_DECLARATION, queryInput, requestContext);

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointDefinition.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointDefinition.java
@@ -9,7 +9,7 @@ package de.ii.ldproxy.ogcapi.common.infra;
 
 import com.google.common.collect.ImmutableList;
 import de.ii.ldproxy.ogcapi.common.app.ImmutableDefinition;
-import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommon;
+import de.ii.ldproxy.ogcapi.common.domain.QueriesHandlerCommon;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl.Query;
 import de.ii.ldproxy.ogcapi.common.domain.ApiDefinitionFormatExtension;
@@ -104,6 +104,7 @@ public class EndpointDefinition extends Endpoint {
                                      @Context ApiRequestContext ogcApiContext, @PathParam("file") Optional<String> file) {
 
         QueriesHandlerCommonImpl.Definition queryInputApiDefinition = new ImmutableDefinition.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .subPath(file)
                 .build();
 

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointLandingPage.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ldproxy/ogcapi/common/infra/EndpointLandingPage.java
@@ -9,7 +9,7 @@ package de.ii.ldproxy.ogcapi.common.infra;
 
 import com.google.common.collect.ImmutableList;
 import de.ii.ldproxy.ogcapi.common.app.ImmutableQueryInputLandingPage;
-import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommon;
+import de.ii.ldproxy.ogcapi.common.domain.QueriesHandlerCommon;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl;
 import de.ii.ldproxy.ogcapi.common.app.QueriesHandlerCommonImpl.Query;
 import de.ii.ldproxy.ogcapi.common.domain.CommonConfiguration;
@@ -22,7 +22,6 @@ import de.ii.ldproxy.ogcapi.domain.Endpoint;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionRegistry;
 import de.ii.ldproxy.ogcapi.domain.FormatExtension;
-import de.ii.ldproxy.ogcapi.domain.FoundationConfiguration;
 import de.ii.ldproxy.ogcapi.domain.FoundationValidator;
 import de.ii.ldproxy.ogcapi.domain.ImmutableApiEndpointDefinition;
 import de.ii.ldproxy.ogcapi.domain.ImmutableOgcApiResourceAuxiliary;
@@ -120,15 +119,12 @@ public class EndpointLandingPage extends Endpoint implements ConformanceClass {
     public Response getLandingPage(@Auth Optional<User> optionalUser, @Context OgcApi api,
                                    @Context ApiRequestContext requestContext) {
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
         List<Link> additionalLinks = api.getData().getExtension(CommonConfiguration.class)
                                         .map(CommonConfiguration::getAdditionalLinks)
                                         .orElse(ImmutableList.of());
 
         QueriesHandlerCommonImpl.QueryInputLandingPage queryInput = new ImmutableQueryInputLandingPage.Builder()
-                .includeLinkHeader(includeLinkHeader)
+                .from(getGenericQueryInput(api.getData()))
                 .additionalLinks(additionalLinks)
                 .build();
 

--- a/ogcapi-stable/ogcapi-common/src/test/groovy/de/ii/ldproxy/ogcapi/LandingPageSpec.groovy
+++ b/ogcapi-stable/ogcapi-common/src/test/groovy/de/ii/ldproxy/ogcapi/LandingPageSpec.groovy
@@ -20,9 +20,15 @@ import de.ii.ldproxy.ogcapi.domain.*
 import de.ii.xtraplatform.crs.domain.BoundingBox
 import de.ii.xtraplatform.crs.domain.OgcCrs
 import io.swagger.v3.oas.models.media.ObjectSchema
+import org.glassfish.jersey.internal.MapPropertiesDelegate
+import org.glassfish.jersey.internal.PropertiesDelegate
+import org.glassfish.jersey.server.ApplicationHandler
+import org.glassfish.jersey.server.ContainerRequest
 import spock.lang.Specification
 
 import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Request
+import javax.ws.rs.core.SecurityContext
 
 class LandingPageSpec extends Specification {
 

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/EndpointFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/EndpointFeatures.java
@@ -375,21 +375,18 @@ public class EndpointFeatures extends EndpointSubCollection {
         int defaultPageSize = coreConfiguration.getDefaultPageSize();
         int maxPageSize = coreConfiguration.getMaximumPageSize();
         boolean showsFeatureSelfLink = coreConfiguration.getShowsFeatureSelfLink();
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
 
         List<OgcApiQueryParameter> allowedParameters = getQueryParameters(extensionRegistry, api.getData(), "/collections/{collectionId}/items", collectionId);
         FeatureQuery query = ogcApiFeaturesQuery.requestToFeatureQuery(api.getData(), collectionData, coreConfiguration, minimumPageSize, defaultPageSize, maxPageSize, toFlatMap(uriInfo.getQueryParameters()), allowedParameters);
 
         FeaturesCoreQueriesHandler.QueryInputFeatures queryInput = new ImmutableQueryInputFeatures.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
                 .query(query)
                 .featureProvider(providers.getFeatureProvider(api.getData(), collectionData))
                 .defaultCrs(coreConfiguration.getDefaultEpsgCrs())
                 .defaultPageSize(Optional.of(defaultPageSize))
                 .showsFeatureSelfLink(showsFeatureSelfLink)
-                .includeLinkHeader(includeLinkHeader)
                 .build();
 
         return queryHandler.handle(FeaturesCoreQueriesHandlerImpl.Query.FEATURES, queryInput, requestContext);
@@ -412,22 +409,21 @@ public class EndpointFeatures extends EndpointSubCollection {
         FeaturesCoreConfiguration coreConfiguration = collectionData.getExtension(FeaturesCoreConfiguration.class)
                                                                     .orElseThrow(() -> new NotFoundException("Features are not supported for this API."));
 
-        boolean includeLinkHeader = api.getData().getExtension(FoundationConfiguration.class)
-                .map(FoundationConfiguration::getIncludeLinkHeader)
-                .orElse(false);
-
         List<OgcApiQueryParameter> allowedParameters = getQueryParameters(extensionRegistry, api.getData(), "/collections/{collectionId}/items/{featureId}", collectionId);
         FeatureQuery query = ogcApiFeaturesQuery.requestToFeatureQuery(api.getData(), collectionData, coreConfiguration, toFlatMap(uriInfo.getQueryParameters()), allowedParameters, featureId);
 
-        FeaturesCoreQueriesHandler.QueryInputFeature queryInput = new ImmutableQueryInputFeature.Builder()
+
+        ImmutableQueryInputFeature.Builder queryInputBuilder = new ImmutableQueryInputFeature.Builder()
+                .from(getGenericQueryInput(api.getData()))
                 .collectionId(collectionId)
                 .featureId(featureId)
                 .query(query)
                 .featureProvider(providers.getFeatureProvider(api.getData(), collectionData))
-                .defaultCrs(coreConfiguration.getDefaultEpsgCrs())
-                .includeLinkHeader(includeLinkHeader)
-                .build();
+                .defaultCrs(coreConfiguration.getDefaultEpsgCrs());
 
-        return queryHandler.handle(FeaturesCoreQueriesHandlerImpl.Query.FEATURE, queryInput, requestContext);
+        if (Objects.nonNull(coreConfiguration.getCaching()) && Objects.nonNull(coreConfiguration.getCaching().getCacheControlItems()))
+            queryInputBuilder.cacheControl(coreConfiguration.getCaching().getCacheControlItems());
+
+        return queryHandler.handle(FeaturesCoreQueriesHandlerImpl.Query.FEATURE, queryInputBuilder.build(), requestContext);
     }
 }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
@@ -11,6 +11,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import de.ii.ldproxy.ogcapi.common.domain.ConformanceDeclaration;
 import de.ii.ldproxy.ogcapi.domain.ApiMediaType;
 import de.ii.ldproxy.ogcapi.domain.ApiRequestContext;
 import de.ii.ldproxy.ogcapi.domain.I18n;
@@ -48,12 +49,15 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.OutputStream;
 import java.text.MessageFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -124,7 +128,7 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
                 Optional.of(collectionId))
                                                  .orElseThrow(() -> new NotAcceptableException(MessageFormat.format("The requested media type ''{0}'' is not supported for this resource.", requestContext.getMediaType())));
 
-        return getItemsResponse(api, requestContext, collectionId, query, queryInput.getFeatureProvider(), true, null, outputFormat, onlyHitsIfMore, defaultPageSize,
+        return getItemsResponse(api, requestContext, collectionId, queryInput, query, queryInput.getFeatureProvider(), true, null, outputFormat, onlyHitsIfMore, defaultPageSize,
                 queryInput.getShowsFeatureSelfLink(), queryInput.getIncludeLinkHeader(), queryInput.getDefaultCrs());
     }
 
@@ -153,11 +157,11 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
             persistentUri = StringTemplateFilters.applyTemplate(template.get(), featureId);
         }
 
-        return getItemsResponse(api, requestContext, collectionId, query, queryInput.getFeatureProvider(), false, persistentUri, outputFormat, false, Optional.empty(),
+        return getItemsResponse(api, requestContext, collectionId, queryInput, query, queryInput.getFeatureProvider(), false, persistentUri, outputFormat, false, Optional.empty(),
                 false, queryInput.getIncludeLinkHeader(), queryInput.getDefaultCrs());
     }
 
-    private Response getItemsResponse(OgcApi api, ApiRequestContext requestContext, String collectionId,
+    private Response getItemsResponse(OgcApi api, ApiRequestContext requestContext, String collectionId, QueryInput queryInput,
                                       FeatureQuery query, FeatureProvider2 featureProvider, boolean isCollection,
                                       String canonicalUri,
                                       FeatureFormatExtension outputFormat,
@@ -176,7 +180,6 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
         if (featureProvider.supportsCrs()) {
             EpsgCrs sourceCrs = featureProvider.crs()
                                                .getNativeCrs();
-            //TODO: warmup on service start
             crsTransformer = crsTransformerFactory.getTransformer(sourceCrs, targetCrs);
             swapCoordinates = crsTransformer.isPresent() && crsTransformer.get()
                                                                           .needsCoordinateSwap();
@@ -241,13 +244,23 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
             throw new NotAcceptableException(MessageFormat.format("The requested media type {0} cannot be generated, because it does not support streaming.", requestContext.getMediaType().type()));
         }
 
+        Date lastModified = getLastModified(queryInput, requestContext.getApi(), featureProvider);
+        EntityTag etag = isCollection ? null : getEtag(lastModified);
+        Response.ResponseBuilder response = evaluatePreconditions(requestContext, lastModified, etag);
+        if (Objects.nonNull(response))
+            return response.build();
+
+        // TODO support lastModified and etag from the content, in particular for a single feature
         // TODO determine numberMatched, numberReturned and optionally return them as OGC-numberMatched and OGC-numberReturned headers
         // TODO For now remove the "next" links from the headers since at this point we don't know, whether there will be a next page
 
-        return prepareSuccessResponse(api, requestContext, includeLinkHeader ? links.stream()
-                                                                                    .filter(link -> !"next".equalsIgnoreCase(link.getRel()))
-                                                                                    .collect(ImmutableList.toImmutableList()) :
-                                                                                null, targetCrs)
+        return prepareSuccessResponse(requestContext.getApi(), requestContext, includeLinkHeader ? links.stream()
+                                                                                                        .filter(link -> !"next".equalsIgnoreCase(link.getRel()))
+                                                                                                        .collect(ImmutableList.toImmutableList()) : null,
+                                      lastModified, etag,
+                                      queryInput.getCacheControl().orElse(null),
+                                      queryInput.getExpires().orElse(null),
+                                      targetCrs)
                 .entity(streamingOutput)
                 .build();
     }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import de.ii.ldproxy.ogcapi.domain.CachingConfiguration;
 import de.ii.ldproxy.ogcapi.domain.ExtensionConfiguration;
 import de.ii.xtraplatform.crs.domain.ImmutableEpsgCrs;
 import de.ii.xtraplatform.crs.domain.OgcCrs;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
 @Value.Immutable
 @Value.Style(builder = "new")
 @JsonDeserialize(builder = ImmutableFeaturesCoreConfiguration.Builder.class)
-public interface FeaturesCoreConfiguration extends ExtensionConfiguration, FeatureTransformations {
+public interface FeaturesCoreConfiguration extends ExtensionConfiguration, FeatureTransformations, CachingConfiguration {
 
     abstract class Builder extends ExtensionConfiguration.Builder {
     }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchema.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchema.java
@@ -9,7 +9,11 @@ package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.PageRepresentation;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Optional;
 
 @JsonTypeInfo(
@@ -22,10 +26,32 @@ import java.util.Optional;
         @JsonSubTypes.Type(value = JsonSchemaObject.class, name = "object"),
         @JsonSubTypes.Type(value = JsonSchemaArray.class, name = "array"),
         @JsonSubTypes.Type(value = JsonSchemaNull.class, name = "null"),
-        @JsonSubTypes.Type(value = JsonSchemaRef.class, name = "$ref")
+        @JsonSubTypes.Type(value = JsonSchemaRef.class, name = "$ref"),
+        @JsonSubTypes.Type(value = JsonSchemaOneOf.class, name = "oneOf")
 })
-public abstract class JsonSchema {
+public abstract class JsonSchema extends PageRepresentation {
 
-    public abstract Optional<String> getTitle();
-    public abstract Optional<String> getDescription();
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchema> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        if (from instanceof JsonSchemaString)
+            JsonSchemaString.FUNNEL.funnel((JsonSchemaString) from, into);
+        else if (from instanceof JsonSchemaNumber)
+            JsonSchemaNumber.FUNNEL.funnel((JsonSchemaNumber) from, into);
+        else if (from instanceof JsonSchemaInteger)
+            JsonSchemaInteger.FUNNEL.funnel((JsonSchemaInteger) from, into);
+        else if (from instanceof JsonSchemaBoolean)
+            JsonSchemaBoolean.FUNNEL.funnel((JsonSchemaBoolean) from, into);
+        else if (from instanceof JsonSchemaObject)
+            JsonSchemaObject.FUNNEL.funnel((JsonSchemaObject) from, into);
+        else if (from instanceof JsonSchemaArray)
+            JsonSchemaArray.FUNNEL.funnel((JsonSchemaArray) from, into);
+        else if (from instanceof JsonSchemaNull)
+            JsonSchemaNull.FUNNEL.funnel((JsonSchemaNull) from, into);
+        else if (from instanceof JsonSchemaRef)
+            JsonSchemaRef.FUNNEL.funnel((JsonSchemaRef) from, into);
+        else if (from instanceof JsonSchemaOneOf)
+            JsonSchemaOneOf.FUNNEL.funnel((JsonSchemaOneOf) from, into);
+    };
+
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaArray.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaArray.java
@@ -8,8 +8,12 @@
 package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
@@ -22,4 +26,12 @@ public abstract class JsonSchemaArray extends JsonSchema {
     public abstract JsonSchema getItems();
     public abstract Optional<Integer> getMinItems();
     public abstract Optional<Integer> getMaxItems();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaArray> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        JsonSchema.FUNNEL.funnel(from.getItems(), into);
+        from.getMinItems().ifPresent(val -> into.putInt(val));
+        from.getMaxItems().ifPresent(val -> into.putInt(val));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaBoolean.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaBoolean.java
@@ -8,7 +8,10 @@
 package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
+
+import java.nio.charset.StandardCharsets;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true)
@@ -17,4 +20,8 @@ public abstract class JsonSchemaBoolean extends JsonSchema {
 
     public final String getType() { return "boolean"; }
 
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaBoolean> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaInteger.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaInteger.java
@@ -9,8 +9,10 @@ package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +27,15 @@ public abstract class JsonSchemaInteger extends JsonSchema {
     public abstract Optional<Long> getMaximum();
     @JsonProperty("enum")
     public abstract List<Integer> getEnums();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaInteger> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        from.getMinimum().ifPresent(val -> into.putLong(val));
+        from.getMaximum().ifPresent(val -> into.putLong(val));
+        from.getEnums()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putInt(val));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaNull.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaNull.java
@@ -8,7 +8,10 @@
 package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
+
+import java.nio.charset.StandardCharsets;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true)
@@ -17,4 +20,8 @@ public abstract class JsonSchemaNull extends JsonSchema {
 
     public final String getType() { return "null"; }
 
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaNull> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaNumber.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaNumber.java
@@ -8,8 +8,10 @@
 package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @Value.Immutable
@@ -21,4 +23,11 @@ public abstract class JsonSchemaNumber extends JsonSchema {
 
     public abstract Optional<Double> getMinimum();
     public abstract Optional<Double> getMaximum();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaNumber> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        from.getMinimum().ifPresent(val -> into.putDouble(val));
+        from.getMaximum().ifPresent(val -> into.putDouble(val));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaObject.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaObject.java
@@ -9,8 +9,13 @@ package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
+import de.ii.ldproxy.ogcapi.domain.Metadata2;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,4 +41,28 @@ public abstract class JsonSchemaObject extends JsonSchema {
     @JsonProperty("definitions")
     public abstract Optional<Map<String, JsonSchema>> getDefinitions();
 
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaObject> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        from.getRequired()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getProperties()
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEachOrdered(entry -> JsonSchema.FUNNEL.funnel(entry.getValue(), into));
+        from.getPatternProperties()
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEachOrdered(entry -> JsonSchema.FUNNEL.funnel(entry.getValue(), into));
+        from.getSchema().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getId().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getDefs().ifPresent(val -> val.entrySet()
+                                           .stream()
+                                           .sorted(Map.Entry.comparingByKey())
+                                           .forEachOrdered(entry -> JsonSchema.FUNNEL.funnel(entry.getValue(), into)));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaOneOf.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaOneOf.java
@@ -7,15 +7,31 @@
  */
 package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true)
 @JsonDeserialize(as = ImmutableJsonSchemaOneOf.class)
 public abstract class JsonSchemaOneOf extends JsonSchema {
 
+    @JsonIgnore
+    public final String getType() { return "oneOf"; }
+
     public abstract List<JsonSchema> getOneOf();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaOneOf> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        from.getOneOf()
+            .stream()
+            .forEachOrdered(val -> JsonSchema.FUNNEL.funnel(val, into));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaRef.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaRef.java
@@ -10,7 +10,10 @@ package de.ii.ldproxy.ogcapi.features.geojson.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
+
+import java.nio.charset.StandardCharsets;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true)
@@ -22,4 +25,10 @@ public abstract class JsonSchemaRef extends JsonSchema {
 
     @JsonProperty("$ref")
     public abstract String getRef();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaRef> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        into.putString(from.getRef(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaString.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchemaString.java
@@ -9,8 +9,10 @@ package de.ii.ldproxy.ogcapi.features.geojson.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +27,15 @@ public abstract class JsonSchemaString extends JsonSchema {
     public abstract Optional<String> getPattern();
     @JsonProperty("enum")
     public abstract List<String> getEnums();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<JsonSchemaString> FUNNEL = (from, into) -> {
+        into.putString(from.getType(), StandardCharsets.UTF_8);
+        from.getFormat().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getPattern().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getEnums()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+    };
 }

--- a/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterCrsSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterCrsSpec.groovy
@@ -24,6 +24,7 @@ import de.ii.xtraplatform.crs.domain.OgcCrs
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.ws.rs.core.Request
 import java.nio.charset.StandardCharsets
 
 class GeoJsonWriterCrsSpec extends Specification {
@@ -161,6 +162,11 @@ class GeoJsonWriterCrsSpec extends Specification {
 
                     @Override
                     Map<String, String> getParameters() {
+                        return null
+                    }
+
+                    @Override
+                    Optional<Request> getRequest() {
                         return null
                     }
                 })

--- a/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterPropertiesSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterPropertiesSpec.groovy
@@ -26,6 +26,7 @@ import de.ii.xtraplatform.features.domain.ImmutableFeatureProperty
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.ws.rs.core.Request
 import java.util.stream.Collectors
 import java.util.stream.IntStream
 
@@ -293,6 +294,11 @@ class GeoJsonWriterPropertiesSpec extends Specification {
 
                     @Override
                     Map<String, String> getParameters() {
+                        return null
+                    }
+
+                    @Override
+                    Optional<Request> getRequest() {
                         return null
                     }
                 })

--- a/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterSetupUtil.groovy
+++ b/ogcapi-stable/ogcapi-features-geojson/src/test/groovy/de/ii/ldproxy/ogcapi/features/geojson/app/GeoJsonWriterSetupUtil.groovy
@@ -20,6 +20,7 @@ import de.ii.ldproxy.ogcapi.features.geojson.domain.ImmutableGeoJsonConfiguratio
 import de.ii.ldproxy.ogcapi.features.geojson.domain.ModifiableStateGeoJson
 import de.ii.xtraplatform.crs.domain.OgcCrs
 
+import javax.ws.rs.core.Request
 import java.nio.charset.StandardCharsets
 
 class GeoJsonWriterSetupUtil {
@@ -83,6 +84,11 @@ class GeoJsonWriterSetupUtil {
 
                     @Override
                     Map<String, String> getParameters() {
+                        return null
+                    }
+
+                    @Override
+                    Optional<Request> getRequest() {
                         return null
                     }
                 })

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/AbstractRequestContext.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/AbstractRequestContext.java
@@ -12,6 +12,8 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
 import java.net.URI;
 import java.util.*;
 
@@ -33,6 +35,9 @@ public abstract class AbstractRequestContext implements ApiRequestContext {
 
     @Override
     public abstract Optional<Locale> getLanguage();
+
+    @Override
+    public abstract Optional<Request> getRequest();
 
     @Value.Derived
     @Override

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/ApiRequestContext.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/ApiRequestContext.java
@@ -7,6 +7,8 @@
  */
 package de.ii.ldproxy.ogcapi.domain;
 
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -26,4 +28,6 @@ public interface ApiRequestContext {
     String getStaticUrlPrefix();
 
     Map<String,String> getParameters();
+
+    Optional<Request> getRequest();
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Caching.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Caching.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ldproxy.ogcapi.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import java.util.Date;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableCaching.Builder.class)
+public interface Caching {
+
+    @Nullable
+    Date getLastModified();
+
+    @Nullable
+    Date getExpires();
+
+    @Nullable
+    String getCacheControl();
+
+    @Nullable
+    String getCacheControlItems();
+
+}

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/CachingConfiguration.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/CachingConfiguration.java
@@ -5,9 +5,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package de.ii.ldproxy.ogcapi.common.app;
+package de.ii.ldproxy.ogcapi.domain;
 
-import de.ii.ldproxy.ogcapi.domain.QueriesHandler;
+import javax.annotation.Nullable;
 
-public interface QueriesHandlerCommon extends QueriesHandler<QueriesHandlerCommonImpl.Query> {
+public interface CachingConfiguration {
+
+    @Nullable
+    Caching getCaching();
+
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/ExternalDocumentation.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/ExternalDocumentation.java
@@ -9,8 +9,12 @@ package de.ii.ldproxy.ogcapi.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 
 @Value.Immutable
@@ -19,4 +23,10 @@ import java.util.Optional;
 public abstract class ExternalDocumentation {
     public abstract Optional<String> getDescription();
     public abstract String getUrl();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<ExternalDocumentation> FUNNEL = (from, into) -> {
+        from.getDescription().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        into.putString(from.getUrl(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Metadata2.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/Metadata2.java
@@ -7,6 +7,10 @@
  */
 package de.ii.ldproxy.ogcapi.domain;
 
+import com.google.common.hash.Funnel;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,5 +31,20 @@ public abstract class Metadata2 extends PageRepresentation {
     public abstract Optional<MetadataDates> getDates();
 
     public abstract Optional<String> getVersion();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<Metadata2> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+        from.getKeywords()
+            .stream()
+            .sorted()
+            .forEachOrdered(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getPublisher().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getPointOfContact().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getLicense().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getAttribution().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getDates().ifPresent(val -> MetadataDates.FUNNEL.funnel(val, into));
+        from.getVersion().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+    };
 
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/MetadataDates.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/MetadataDates.java
@@ -8,8 +8,10 @@
 package de.ii.ldproxy.ogcapi.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.hash.Funnel;
 import org.immutables.value.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @Value.Immutable
@@ -22,4 +24,14 @@ public abstract class MetadataDates {
     public abstract Optional<String> getRevision();
     public abstract Optional<String> getValidTill();
     public abstract Optional<String> getReceivedOn();
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<MetadataDates> FUNNEL = (from, into) -> {
+        from.getCreation().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getPublication().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getRevision().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getValidTill().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+        from.getReceivedOn().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
+    };
+
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/OgcApiDataV2.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/OgcApiDataV2.java
@@ -80,6 +80,8 @@ public abstract class OgcApiDataV2 implements ServiceData, ExtendableConfigurati
 
     public abstract Optional<CollectionExtent> getDefaultExtent();
 
+    public abstract Optional<Caching> getDefaultCaching();
+
     @Value.Default
     public MODE getApiValidation() {
         return MODE.NONE;

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/PageRepresentationWithId.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/PageRepresentationWithId.java
@@ -7,8 +7,17 @@
  */
 package de.ii.ldproxy.ogcapi.domain;
 
+import com.google.common.hash.Funnel;
+
+import java.nio.charset.StandardCharsets;
+
 public abstract class PageRepresentationWithId extends PageRepresentation {
 
     public abstract String getId();
 
+    @SuppressWarnings("UnstableApiUsage")
+    public static final Funnel<PageRepresentationWithId> FUNNEL = (from, into) -> {
+        PageRepresentation.FUNNEL.funnel(from, into);
+         into.putString(from.getId(), StandardCharsets.UTF_8);
+    };
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -9,15 +9,11 @@ package de.ii.ldproxy.ogcapi.domain;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Funnel;
-import com.google.common.hash.HashCode;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
 import com.google.common.io.Files;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import de.ii.xtraplatform.features.domain.FeatureProvider2;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,24 +24,25 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SimpleTimeZone;
 import java.util.stream.Collectors;
 
-import static de.ii.xtraplatform.codelists.domain.FeaturePropertyTransformerCodelist.LOGGER;
-
 public interface QueriesHandler<T extends QueryIdentifier> {
+
+    Logger LOGGER = LoggerFactory.getLogger(QueriesHandler.class);
 
     Locale[] LANGUAGES = I18n.getLanguages()
                              .stream()

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -7,14 +7,51 @@
  */
 package de.ii.ldproxy.ogcapi.domain;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.hash.HashingInputStream;
+import com.google.common.io.Files;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import de.ii.xtraplatform.features.domain.FeatureProvider2;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
+import javax.xml.bind.DatatypeConverter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
+
+import static de.ii.xtraplatform.codelists.domain.FeaturePropertyTransformerCodelist.LOGGER;
 
 public interface QueriesHandler<T extends QueryIdentifier> {
+
+    Locale[] LANGUAGES = I18n.getLanguages()
+                             .stream()
+                             .collect(Collectors.toUnmodifiableList())
+                             .toArray(Locale[]::new);
+    String[] ENCODINGS = {"gzip", "identity"};
 
     Map<T, QueryHandler<? extends QueryInput>> getQueryHandlers();
 
@@ -68,6 +105,153 @@ public interface QueriesHandler<T extends QueryIdentifier> {
             response.header("Content-Crs", "<" + crs.toUriString() + ">");
 
         return response;
+    }
+
+    default Response.ResponseBuilder evaluatePreconditions(ApiRequestContext requestContext,
+                                                           Date lastModified,
+                                                           EntityTag etag) {
+        if (requestContext.getRequest().isPresent()) {
+            Request request = requestContext.getRequest().get();
+            try {
+                if (Objects.nonNull(lastModified) && Objects.nonNull(etag))
+                    return request.evaluatePreconditions(lastModified, etag);
+                else if (Objects.nonNull(etag))
+                    return request.evaluatePreconditions(etag);
+                else if (Objects.nonNull(lastModified))
+                    return request.evaluatePreconditions(lastModified);
+                else
+                    return request.evaluatePreconditions();
+            } catch (Exception e) {
+                // could not parse headers, so silently ignore them and return the regular response
+                LOGGER.debug("Ignoring invalid condition request headers: {}", e.getMessage());
+            }
+        }
+
+        return null;
+    }
+
+    default Response.ResponseBuilder prepareSuccessResponse(OgcApi api,
+                                                            ApiRequestContext requestContext,
+                                                            List<Link> links,
+                                                            Date lastModified,
+                                                            EntityTag etag,
+                                                            String cacheControl,
+                                                            Date expires,
+                                                            EpsgCrs crs) {
+        Response.ResponseBuilder response = Response.ok()
+                                                    .type(requestContext
+                                                                  .getMediaType()
+                                                                  .type());
+
+        if (Objects.nonNull(lastModified))
+            response.lastModified(lastModified);
+
+        if (Objects.nonNull(etag))
+            response.tag(etag);
+
+        if (Objects.nonNull(cacheControl))
+            response.cacheControl(CacheControl.valueOf(cacheControl));
+
+        if (Objects.nonNull(expires))
+            response.expires(expires);
+
+        response.variants(Variant.mediaTypes(new ImmutableList.Builder<ApiMediaType>().add(requestContext.getMediaType())
+                                                                                      .addAll(requestContext.getAlternateMediaTypes())
+                                                                                      .build()
+                                                                                      .stream()
+                                                                                      .map(ApiMediaType::type)
+                                                                                      .toArray(MediaType[]::new))
+                                 .languages(LANGUAGES)
+                                 .encodings(ENCODINGS)
+                                 .add()
+                                 .build());
+
+        requestContext.getLanguage()
+                      .ifPresent(response::language);
+
+        if (links != null)
+            // skip URI templates in the header as these are not RFC 8288 links
+            links.stream()
+                 .filter(link -> link.getTemplated()==null || !link.getTemplated())
+                 .forEach(link -> response.links(link.getLink()));
+
+        if (crs != null)
+            response.header("Content-Crs", "<" + crs.toUriString() + ">");
+
+        return response;
+    }
+
+    default Date getLastModified(QueryInput queryInput, PageRepresentation resource) {
+        return queryInput.getLastModified()
+                         .orElse(resource.getLastModified()
+                                         .orElse(Date.from(Instant.now())));
+    }
+
+    default Date getLastModified(QueryInput queryInput, OgcApi api) {
+        return queryInput.getLastModified()
+                         .orElse(Date.from(Instant.ofEpochMilli(api.getData()
+                                                                   .getLastModified())));
+    }
+
+    default Date getLastModified(QueryInput queryInput, OgcApi api, FeatureProvider2 provider) {
+        return queryInput.getLastModified()
+                         .orElse(Date.from(Instant.ofEpochMilli(Math.max(api.getData()
+                                                                            .getLastModified(),
+                                                                         provider.getData()
+                                                                                 .getLastModified()))));
+    }
+
+    default Date getLastModified(File file) {
+        return Date.from(Instant.ofEpochMilli(file.lastModified()));
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    default EntityTag getEtag(Date date) {
+        if (Objects.isNull(date))
+            return null;
+
+        SimpleDateFormat sdf = new SimpleDateFormat();
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
+        String etag = Hashing.murmur3_128()
+                             .hashString(sdf.format(date), StandardCharsets.UTF_8)
+                             .toString();
+        return new EntityTag(etag, true);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    default EntityTag getEtag(byte[] byteArray) {
+        String etag = Hashing.murmur3_128()
+                             .hashBytes(byteArray)
+                             .toString();
+        return new EntityTag(etag, false);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    default EntityTag getEtag(File file) {
+        String etag;
+        try {
+            etag = Files.asByteSource(file).hash(Hashing.murmur3_128()).toString();
+        } catch (IOException e) {
+            return null;
+        }
+        return new EntityTag(etag, false);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    default EntityTag getEtag(InputStream inputStream) {
+        String etag = new HashingInputStream(Hashing.murmur3_128(), inputStream).hash().toString();
+        return new EntityTag(etag, false);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    default <S extends PageRepresentation> EntityTag getEtag(S entity, Funnel<S> funnel, FormatExtension outputFormat) {
+        String etag = Hashing.murmur3_128()
+                             .newHasher()
+                             .putObject(entity, funnel)
+                             .putString(Objects.nonNull(outputFormat) ? outputFormat.getMediaType().label() : "", StandardCharsets.UTF_8)
+                             .toString();
+        return new EntityTag(etag, true);
     }
 
     /**

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -250,6 +250,7 @@ public interface QueriesHandler<T extends QueryIdentifier> {
                              .newHasher()
                              .putObject(entity, funnel)
                              .putString(Objects.nonNull(outputFormat) ? outputFormat.getMediaType().label() : "", StandardCharsets.UTF_8)
+                             .hash()
                              .toString();
         return new EntityTag(etag, true);
     }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueryInput.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueryInput.java
@@ -9,9 +9,18 @@ package de.ii.ldproxy.ogcapi.domain;
 
 import org.immutables.value.Value;
 
+import java.util.Date;
+import java.util.Optional;
+
 public interface QueryInput {
 
     // general output options
     @Value.Default
     default boolean getIncludeLinkHeader() { return false; }
+
+    Optional<Date> getLastModified();
+
+    Optional<Date> getExpires();
+
+    Optional<String> getCacheControl();
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/infra/rest/ApiRequestDispatcher.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/infra/rest/ApiRequestDispatcher.java
@@ -20,9 +20,12 @@ import javax.annotation.security.PermitAll;
 import javax.ws.rs.*;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
 import java.net.URI;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -63,14 +66,14 @@ public class ApiRequestDispatcher implements ServiceEndpoint {
 
     @Path("")
     public EndpointExtension dispatchLandingPageWithoutSlash(@PathParam("entrypoint") String entrypoint, @Context OgcApi service,
-                                                             @Context ContainerRequestContext requestContext) {
-        return dispatch("", service, requestContext);
+                                                             @Context ContainerRequestContext requestContext, @Context Request request) {
+        return dispatch("", service, requestContext, request);
 
     }
 
     @Path("/{entrypoint: [^/]*}")
     public EndpointExtension dispatch(@PathParam("entrypoint") String entrypoint, @Context OgcApi service,
-                                      @Context ContainerRequestContext requestContext) {
+                                      @Context ContainerRequestContext requestContext, @Context Request request) {
 
         String subPath = ((UriRoutingContext) requestContext.getUriInfo()).getFinalMatchingGroup();
         String method = requestContext.getMethod();
@@ -123,6 +126,7 @@ public class ApiRequestDispatcher implements ServiceEndpoint {
         ApiRequestContext apiRequestContext = new ImmutableRequestContext.Builder()
                 .requestUri(requestContext.getUriInfo()
                                           .getRequestUri())
+                .request(request)
                 .externalUri(getExternalUri())
                 .mediaType(selectedMediaType)
                 .alternateMediaTypes(alternateMediaTypes)

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/infra/rest/OptionsEndpoint.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/infra/rest/OptionsEndpoint.java
@@ -103,6 +103,7 @@ public class OptionsEndpoint implements EndpointExtension {
         return Response
                 .ok(String.join(", ", supportedMethods))
                 .allow(supportedMethods)
+                // TODO add variants
                 .header("Access-Control-Allow-Origin","*") // TODO * not allowed with credentials
                 .header("Access-Control-Allow-Credentials","true")
                 .header("Access-Control-Allow-Methods", String.join(", ", supportedMethods))


### PR DESCRIPTION
closes #475 

The code has been deployed in the [t17-APIs](https://t17.ldproxy.net).

Guava is used for the ETag hashing with murmur3_128 as the hash function based on this [comparison](http://goo.gl/jS7HH) linked from the [Javadoc](https://guava.dev/releases/snapshot/api/docs/com/google/common/hash/Hashing.html).

