### PR TITLE
support 'now' in datetime parameter and in CQL filters

### DIFF
--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesQueryImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/app/FeaturesQueryImpl.java
@@ -352,7 +352,8 @@ public class FeaturesQueryImpl implements FeaturesQuery {
     private Optional<CqlPredicate> timeToCql(String timeField, String timeValue) {
         // valid values: timestamp or time interval;
         // this includes open intervals indicated by ".." (see ISO 8601-2);
-        // accept also unknown ("") with the same interpretation
+        // accept also unknown ("") with the same interpretation;
+        // in addition, "now" is accepted for the current time
 
         TemporalLiteral temporalLiteral;
         try {

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/AbstractQueryParameterDatetime.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ldproxy/ogcapi/features/core/domain/AbstractQueryParameterDatetime.java
@@ -16,17 +16,18 @@ import io.swagger.v3.oas.models.media.StringSchema;
 
 public abstract class AbstractQueryParameterDatetime extends ApiExtensionCache implements OgcApiQueryParameter {
 
+    private static final String NOW_REGEX = "(?:[nN][oO][wW])";
     private static final String OPEN_REGEX = "(?:\\.\\.)?";
     private static final String LOCAL_DATE_REGEX = "(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])";
-    private static final String LOCAL_DATE_OR_OPEN_REGEX = "(?:"+LOCAL_DATE_REGEX+"|"+OPEN_REGEX+")";
+    private static final String LOCAL_DATE_OR_OPEN_REGEX = "(?:"+LOCAL_DATE_REGEX+"|"+OPEN_REGEX+"|"+NOW_REGEX+")";
     private static final String LOCAL_DATE_OPEN_INTERVAL_REGEX = LOCAL_DATE_OR_OPEN_REGEX+"/"+LOCAL_DATE_OR_OPEN_REGEX;
     private static final String LOCAL_DATE_CLOSED_INTERVAL_REGEX = LOCAL_DATE_REGEX+"/"+LOCAL_DATE_REGEX;
     private static final String OFFSET_DATE_TIME_REGEX = LOCAL_DATE_REGEX + "T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9]|60)(?:\\.[0-9]+)?(Z|(\\+|-)(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]))";
-    private static final String OFFSET_DATE_TIME_OR_OPEN_REGEX = "(?:"+OFFSET_DATE_TIME_REGEX+"|"+OPEN_REGEX+")";
+    private static final String OFFSET_DATE_TIME_OR_OPEN_REGEX = "(?:"+OFFSET_DATE_TIME_REGEX+"|"+OPEN_REGEX+"|"+NOW_REGEX+")";
     private static final String OFFSET_DATE_TIME_OPEN_INTERVAL_REGEX = OFFSET_DATE_TIME_OR_OPEN_REGEX+"/"+OFFSET_DATE_TIME_OR_OPEN_REGEX;
     private static final String OFFSET_DATE_TIME_CLOSED_INTERVAL_REGEX = OFFSET_DATE_TIME_REGEX+"/"+OFFSET_DATE_TIME_REGEX;
-    private static final String DATETIME_OPEN_REGEX = "^"+LOCAL_DATE_REGEX + "$|^" + LOCAL_DATE_OPEN_INTERVAL_REGEX + "$|^" + OFFSET_DATE_TIME_REGEX + "$|^" + OFFSET_DATE_TIME_OPEN_INTERVAL_REGEX + "$";
-    private static final String DATETIME_CLOSED_REGEX = "^"+LOCAL_DATE_REGEX + "$|^" + LOCAL_DATE_CLOSED_INTERVAL_REGEX + "$|^" + OFFSET_DATE_TIME_REGEX + "$|^" + OFFSET_DATE_TIME_CLOSED_INTERVAL_REGEX + "$";
+    private static final String DATETIME_OPEN_REGEX = "^" + LOCAL_DATE_REGEX + "$|^" + NOW_REGEX + "$|^" + LOCAL_DATE_OPEN_INTERVAL_REGEX + "$|^" + OFFSET_DATE_TIME_REGEX + "$|^" + OFFSET_DATE_TIME_OPEN_INTERVAL_REGEX + "$";
+    private static final String DATETIME_CLOSED_REGEX = "^" + LOCAL_DATE_REGEX + "$|^" + NOW_REGEX + "$|^" + LOCAL_DATE_CLOSED_INTERVAL_REGEX + "$|^" + OFFSET_DATE_TIME_REGEX + "$|^" + OFFSET_DATE_TIME_CLOSED_INTERVAL_REGEX + "$";
 
     private final Schema baseSchema;
 
@@ -41,11 +42,13 @@ public abstract class AbstractQueryParameterDatetime extends ApiExtensionCache i
 
     @Override
     public String getDescription() {
-        return "Either a local date, a date-time with offsets or an open or closed interval. Date and time expressions adhere to RFC 3339. \n"+
+        return "Either a local date, a date-time with time zone, 'now' or an open or closed interval. Date and time expressions adhere to RFC 3339. \n"+
                 "Examples:\n\n" +
                 "* A date-time: '2018-02-12T23:20:50Z'\n" +
                 "* A closed interval: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'\n" +
                 "* Open intervals: '2018-02-12T00:00:00Z/..' or '../2018-03-18T12:31:12Z'\n\n" +
+                "* Now: 'now'\n" +
+                "* An interval until now: '2018-02-12T00:00:00Z/now'\n" +
                 "Selects features that have a temporal property that intersects the value of the parameter.";
     }
 


### PR DESCRIPTION
closes #481

See also https://github.com/interactive-instruments/xtraplatform-spatial/pull/83 for the changes in xtraplatform-spatial. The main changes are in that PR to extend the CQL grammar and to handle 'now' as part of the TemporalLiteral class.

