### PR TITLE
remove duplicate "url" key from schema.org markup

### DIFF
--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ldproxy/ogcapi/features/html/app/FeatureEncoderHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ldproxy/ogcapi/features/html/app/FeatureEncoderHtml.java
@@ -186,7 +186,6 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
 
     if (transformationContext.isSchemaOrgEnabled()) {
       feature.itemType("http://schema.org/Place");
-      feature.getId().ifPresent(id -> id.itemProp("url"));
     }
 
     transformationContext.collectionView().features.add(feature);


### PR DESCRIPTION
required to fix errors reported by the Google Search Console