### PR TITLE
ignore lastModified entries in provider/service configs

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -181,21 +181,29 @@ public interface QueriesHandler<T extends QueryIdentifier> {
     default Date getLastModified(QueryInput queryInput, PageRepresentation resource) {
         return queryInput.getLastModified()
                          .orElse(resource.getLastModified()
-                                         .orElse(Date.from(Instant.now())));
+                                         .orElse(null));
     }
 
     default Date getLastModified(QueryInput queryInput, OgcApi api) {
         return queryInput.getLastModified()
+                         .orElse(null);
+                         /* TODO since the information in the service configuration is not updated,
+                             if the file is updated outside of the manager, this is currently not a reliable mechanism
                          .orElse(Date.from(Instant.ofEpochMilli(api.getData()
                                                                    .getLastModified())));
+                          */
     }
 
     default Date getLastModified(QueryInput queryInput, OgcApi api, FeatureProvider2 provider) {
         return queryInput.getLastModified()
+                         .orElse(null);
+                         /* TODO since the information in the provider or service configuration is not updated,
+                             if the file is updated outside of the manager, this is currently not a reliable mechanism
                          .orElse(Date.from(Instant.ofEpochMilli(Math.max(api.getData()
                                                                             .getLastModified(),
                                                                          provider.getData()
                                                                                  .getLastModified()))));
+                          */
     }
 
     default Date getLastModified(File file) {


### PR DESCRIPTION
A follow-up from #508. Since the last-modified-timestamps in configurations are often outdated, clients sometimes do not fetch the latest version and use an outdated copy from some cache. This includes harvesters from search engines.