### PR TITLE
Fix bounding box of a tile matrix set in CRS84

### DIFF
--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/tileMatrixSet/TileMatrixSetImpl.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/tileMatrixSet/TileMatrixSetImpl.java
@@ -176,6 +176,8 @@ public class TileMatrixSetImpl implements TileMatrixSet {
 
     @Override
     public BoundingBox getBoundingBoxCrs84(CrsTransformerFactory crsTransformerFactory) throws CrsTransformationException {
+        if (getCrs().equals(OgcCrs.CRS84))
+            return getBoundingBox();
         CrsTransformer crsTransformer = crsTransformerFactory.getTransformer(getCrs(), OgcCrs.CRS84)
                                                              .orElseThrow(() -> new IllegalStateException(String.format("Could not transform the bounding box of tile matrix set '%s' to CRS84.", getId())));
         return crsTransformer.transformBoundingBox(getBoundingBox());


### PR DESCRIPTION
Correct an error introduced in #520. If the tile matrix set is based on CRS84, there is no need for a transformation.