### PR TITLE
Fix HTTP error code for an invalid CQL filter

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -288,8 +288,9 @@ public interface QueriesHandler<T extends QueryIdentifier> {
             }
         }
 
-        if (error.getCause().getClass().getSimpleName().equals("PSQLException")) {
-            throw new IllegalArgumentException(errorMessage);
+        if (error.getCause().getClass().getSimpleName().equals("PSQLException") &&
+                error.getCause().getMessage().contains("ERROR: operator does not exist")) {
+            throw new IllegalArgumentException(error.getCause().getMessage());
         }
 
         throw new InternalServerErrorException(errorMessage, error);

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ldproxy/ogcapi/domain/QueriesHandler.java
@@ -288,6 +288,10 @@ public interface QueriesHandler<T extends QueryIdentifier> {
             }
         }
 
+        if (error.getCause().getClass().getSimpleName().equals("PSQLException")) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+
         throw new InternalServerErrorException(errorMessage, error);
     }
 


### PR DESCRIPTION
Change HTTP response code from 500 to 400 for CQL filters that compare string properties with integer values, as described in https://github.com/interactive-instruments/ldproxy/issues/538. 