### PR TITLE
de-serialization of JSON schemas

### DIFF
--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchema.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ldproxy/ogcapi/features/geojson/domain/JsonSchema.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 @JsonTypeInfo(
-        use = JsonTypeInfo.Id.NONE)
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = JsonSchemaString.class, name = "string"),
         @JsonSubTypes.Type(value = JsonSchemaNumber.class, name = "number"),


### PR DESCRIPTION
This is required, e.g., for style metadata, which requires this capability with v3.1