### PR TITLE
fix distinction between dataset and collection tiles

### DIFF
--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/FeatureEncoderMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/FeatureEncoderMVT.java
@@ -216,10 +216,11 @@ public class FeatureEncoderMVT extends FeatureObjectEncoder<PropertyMVT, Feature
       long encoderDuration = (System.nanoTime() - encoderStart) / 1000000;
       long transformerDuration = (System.nanoTime() - transformerStart) / 1000000;
       long processingDuration = (System.nanoTime() - processingStart) / 1000000;
-      String text = String.format("Collection %s, tile %s/%d/%d/%d written. Features returned: %d, written: %d, total duration: %dms, processing: %dms, feature post-processing: %dms, average feature post-processing: %dms, merging: %dms, encoding: %dms.",
+      int kiloBytes = mvt.length/1024;
+      String text = String.format("Collection %s, tile %s/%d/%d/%d written. Features returned: %d, written: %d, total duration: %dms, processing: %dms, feature post-processing: %dms, average feature post-processing: %dms, merging: %dms, encoding: %dms, size: %dkB.",
           collectionId, tileMatrixSet.getId(), tile.getTileLevel(), tile.getTileRow(), tile.getTileCol(), context.metadata().getNumberReturned().orElse(0), written,
-          transformerDuration, processingDuration, featureDuration / 1000000, featureCount == 0 ? 0 : featureDuration / featureCount / 1000000, mergerDuration, encoderDuration);
-      if (processingDuration > 200)
+          transformerDuration, processingDuration, featureDuration / 1000000, featureCount == 0 ? 0 : featureDuration / featureCount / 1000000, mergerDuration, encoderDuration, kiloBytes);
+      if (processingDuration > 200 || kiloBytes > 50)
         LOGGER.debug(text);
       else
         LOGGER.trace(text);

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
@@ -594,9 +594,8 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
     private Response getTileServerTileResponse(QueryInputTileTileServerTile queryInput, ApiRequestContext requestContext) {
 
         Tile tile = queryInput.getTile();
-        String collectionId = tile.getCollectionId();
 
-        final String urlTemplate = Objects.isNull(collectionId)
+        final String urlTemplate = tile.isDatasetTile()
             ? queryInput.getProvider().getUrlTemplate()
             : queryInput.getProvider().getUrlTemplateSingleCollection();
 
@@ -610,7 +609,7 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
             .resolveTemplate("tileRow", tile.getTileRow())
             .resolveTemplate("tileCol", tile.getTileCol())
             .resolveTemplate("fileExtension", mediaType.fileExtension());
-        if (Objects.nonNull(collectionId))
+        if (Objects.nonNull(tile.getCollectionId()))
             client = client.resolveTemplate("collectionId", tile.getCollectionId());
         Response response = client.request(mediaType.type()).get();
 

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/Tile.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/domain/Tile.java
@@ -99,7 +99,7 @@ public abstract class Tile {
     @Value.Derived
     @Value.Auxiliary
     public String getCollectionId() {
-        return getCollectionIds().size()==1 ?
+        return !isDatasetTile() && getCollectionIds().size()==1 ?
                 getCollectionIds().get(0) :
                 null;
     }


### PR DESCRIPTION
There was a bug that took a dataset (multi-collection) tile as a collection tile in an API with only a single collection.