### PR TITLE
improve tile query

### DIFF
--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TileFormatMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ldproxy/ogcapi/tiles/app/TileFormatMVT.java
@@ -7,6 +7,7 @@
  */
 package de.ii.ldproxy.ogcapi.tiles.app;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.ii.ldproxy.ogcapi.domain.ApiMediaType;
@@ -35,8 +36,10 @@ import de.ii.xtraplatform.cql.domain.Cql;
 import de.ii.xtraplatform.cql.domain.CqlFilter;
 import de.ii.xtraplatform.cql.domain.CqlPredicate;
 import de.ii.xtraplatform.cql.domain.Intersects;
+import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.CrsTransformationException;
 import de.ii.xtraplatform.crs.domain.CrsTransformerFactory;
+import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import de.ii.xtraplatform.crs.domain.OgcCrs;
 import de.ii.xtraplatform.features.domain.FeatureQuery;
 import de.ii.xtraplatform.features.domain.FeatureTokenEncoder;
@@ -203,7 +206,28 @@ public class TileFormatMVT extends TileFormatWithQuerySupportExtension {
             parameter.transformQuery(collectionData, queryBuilder, queryParameters, apiData);
         }
 
-        CqlPredicate spatialPredicate = CqlPredicate.of(Intersects.of(filterableFields.get(PARAMETER_BBOX), tile.getBoundingBox()));
+        BoundingBox bbox = tile.getBoundingBox();
+        try {
+            // reduce bbox to the area in which there is data (to avoid coordinate transformation issues
+            // with large scale and data that is stored in a regional, projected CRS)
+            final EpsgCrs crs = bbox.getEpsgCrs();
+            final Optional<BoundingBox> dataBbox = apiData.getSpatialExtent(collectionId, crsTransformerFactory, crs);
+            if (dataBbox.isPresent()) {
+                bbox = ImmutableList.of(bbox, dataBbox.get())
+                    .stream()
+                    .map(BoundingBox::toArray)
+                    .reduce((doubles, doubles2) -> new double[]{
+                        Math.max(doubles[0], doubles2[0]),
+                        Math.max(doubles[1], doubles2[1]),
+                        Math.min(doubles[2], doubles2[2]),
+                        Math.min(doubles[3], doubles2[3])})
+                    .map(doubles -> BoundingBox.of(doubles[0], doubles[1], doubles[2], doubles[3], crs))
+                    .orElse(bbox);
+            }
+        } catch (CrsTransformationException e) {
+            // ignore
+        }
+        CqlPredicate spatialPredicate = CqlPredicate.of(Intersects.of(filterableFields.get(PARAMETER_BBOX), bbox));
         if (predefFilter != null || !filters.isEmpty()) {
             Optional<CqlFilter> otherFilter = Optional.empty();
             Optional<CqlFilter> configFilter = Optional.empty();


### PR DESCRIPTION
In feature queries for a vector tile, reduce the bounding box of the tile to the part of the tile with data. This avoids coordinate transformation issues with tiles at large scales and data that is stored in a regional, projected CRS.

closes #594