### PR TITLE
bump java-vector-tile dep to 1.3.16

### DIFF
--- a/ogcapi-draft/ogcapi-tiles/build.gradle
+++ b/ogcapi-draft/ogcapi-tiles/build.gradle
@@ -1,18 +1,12 @@
 
 dependencies {
-    embedded (group: 'no.ecc.vectortile', name: 'java-vector-tile', version: '1.3.15') {
+    embedded (group: 'no.ecc.vectortile', name: 'java-vector-tile', version: '1.3.16') {
         exclude module: 'jts-core'
         exclude module: 'jts-io-common'
     }
 
     testImplementation(testFixtures(group: 'de.interactive_instruments', name: 'ogcapi-foundation'))
     testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7'
-}
-
-repositories {
-    maven {
-        url "https://maven.ecc.no/releases"
-    }
 }
 
 moduleInfo {


### PR DESCRIPTION
* version 1.3.16 references JTS 1.18.2 (note that ldproxy 3.2.1 already uses JTS 1.18.2 with version 1.3.15)
* remove redundant repository declaration