### PR TITLE
add itemCount to the Collection resources

### DIFF
--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionView.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionView.java
@@ -33,6 +33,7 @@ public class OgcApiCollectionView extends OgcApiDatasetView {
 
     private final OgcApiCollection collection;
     public String itemType;
+    public final Optional<Long> itemCount;
     public boolean spatialSearch;
     public Map<String, String> temporalExtent;
     public List<String> crs;
@@ -40,8 +41,9 @@ public class OgcApiCollectionView extends OgcApiDatasetView {
     public String storageCrs;
     public Metadata metadata;
     public Link items;
-    public String defaultStyle;
+    public final Optional<String> defaultStyle;
     public final String itemTypeTitle;
+    public final String itemCountTitle;
     public final String dataTitle;
     public final String metadataTitle;
     public final String licenseTitle;
@@ -88,12 +90,12 @@ public class OgcApiCollectionView extends OgcApiDatasetView {
                 .getStorageCrs()
                 .orElse(null);
         this.hasGeometry = spatialExtent.isPresent();
-        Optional<String> defaultStyleOrNull = (Optional<String>) collection.getExtensions()
-                                                                           .get("defaultStyle");
-        this.defaultStyle = defaultStyleOrNull==null ? null : defaultStyleOrNull.get();
+        this.defaultStyle = collection.getDefaultStyle();
+        this.itemCount = collection.getItemCount();
         this.spatialSearch = false;
         this.itemType = i18n.get(collection.getItemType().orElse("feature"), language);
         this.itemTypeTitle = i18n.get("itemTypeTitle", language);
+        this.itemCountTitle = i18n.get("itemCountTitle", language);
         this.dataTitle = i18n.get("dataTitle", language);
         this.licenseTitle = i18n.get("licenseTitle", language);
         this.metadataTitle = i18n.get("metadataTitle", language);

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionsView.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionsView.java
@@ -135,7 +135,8 @@ public class OgcApiCollectionsView extends OgcApiView {
                                 .filter(link -> link.getRel().equalsIgnoreCase("self"))
                                 .findFirst()
                                 .map(link -> link.getHref() + "/items")
-                                .orElse("")))
+                                .orElse(""),
+                        "itemCount", collection.getItemCount().map(Object::toString).orElse("")))
                 .collect(Collectors.toList());
     }
 }

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionsView.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/html/OgcApiCollectionsView.java
@@ -27,6 +27,8 @@ public class OgcApiCollectionsView extends OgcApiView {
     private final List<OgcApiCollection> collections;
     private final boolean showCollectionDescriptions;
     public final boolean hasGeometry;
+    private final I18n i18n;
+    private final Optional<Locale> language;
     public String dataSourceUrl;
     public String keywords;
     public List<String> crs;
@@ -52,6 +54,8 @@ public class OgcApiCollectionsView extends OgcApiView {
                 collections
                         .getDescription()
                         .orElse("") );
+        this.i18n = i18n;
+        this.language = language;
         this.collections = collections.getCollections();
         this.showCollectionDescriptions = showCollectionDescriptions;
         this.crs = collections
@@ -136,6 +140,7 @@ public class OgcApiCollectionsView extends OgcApiView {
                                 .findFirst()
                                 .map(link -> link.getHref() + "/items")
                                 .orElse(""),
+                        "itemType", i18n.get(collection.getItemType().orElse("feature"), language),
                         "itemCount", collection.getItemCount().map(Object::toString).orElse("")))
                 .collect(Collectors.toList());
     }

--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/domain/OgcApiCollection.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/domain/OgcApiCollection.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.collections.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.hash.Funnel;
 import de.ii.ogcapi.common.domain.OgcApiExtent;
@@ -15,6 +16,7 @@ import de.ii.ogcapi.foundation.domain.PageRepresentation;
 import de.ii.ogcapi.foundation.domain.PageRepresentationWithId;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,24 @@ public abstract class OgcApiCollection extends PageRepresentationWithId {
 
     @JsonAnyGetter
     public abstract Map<String, Object> getExtensions();
+
+    @JsonIgnore
+    @Value.Derived
+    @Value.Auxiliary
+    public Optional<String> getDefaultStyle() {
+        return getExtensions().containsKey("defaultStyle")
+            ? Optional.of((String) getExtensions().get("defaultStyle"))
+            : Optional.empty();
+    }
+
+    @JsonIgnore
+    @Value.Derived
+    @Value.Auxiliary
+    public Optional<Long> getItemCount() {
+        return getExtensions().containsKey("itemCount")
+            ? Optional.of((Long) getExtensions().get("itemCount"))
+            : Optional.empty();
+    }
 
     @SuppressWarnings("UnstableApiUsage")
     public static final Funnel<OgcApiCollection> FUNNEL = (from, into) -> {

--- a/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collection.mustache
+++ b/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collection.mustache
@@ -38,6 +38,19 @@
 
     <h2>{{collectionInformationTitle}}</h2>
 
+    {{#itemCount}}
+        <div class="row my-3">
+            <div class="col-md-2 font-weight-bold">{{itemCountTitle}}</div>
+            <div class="col-md-10">
+                <ul class="list-unstyled">
+                    <li>
+                        <span id="itemCount">{{.}}</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    {{/itemCount}}
+
     {{#bbox}}
     <div class="row my-3">
         <div class="col-md-2 font-weight-bold">{{spatialExtentTitle}}</div>

--- a/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collections.mustache
+++ b/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collections.mustache
@@ -13,7 +13,7 @@
             <ul class="list-unstyled">
                 {{#collections}}
                     <li>
-                        <a href="{{hrefitems}}">{{title}}</a> {{#itemCount}}({{.}}) {{/itemCount}}<small>— <a href="{{hrefcollection}}">{{moreInformation}}</a></small>
+                        <a href="{{hrefitems}}">{{title}}</a> <small>— <a href="{{hrefcollection}}">{{moreInformation}}</a>{{#itemCount}} — <span class="text-secondary">{{.}} {{itemType}}</span>{{/itemCount}}</small>
                         {{#description}}<ul class="list-unstyled">
                             <li class="list-group-item pt-0 pb-2 small text-secondary" style="border: none">{{{.}}}</li>
                         </ul>{{/description}}

--- a/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collections.mustache
+++ b/ogcapi-stable/ogcapi-collections/src/main/resources/de/ii/ogcapi/collections/templates/collections.mustache
@@ -13,7 +13,7 @@
             <ul class="list-unstyled">
                 {{#collections}}
                     <li>
-                        <a href="{{hrefitems}}">{{title}}</a> <small>— <a href="{{hrefcollection}}">{{moreInformation}}</a></small>
+                        <a href="{{hrefitems}}">{{title}}</a> {{#itemCount}}({{.}}) {{/itemCount}}<small>— <a href="{{hrefcollection}}">{{moreInformation}}</a></small>
                         {{#description}}<ul class="list-unstyled">
                             <li class="list-group-item pt-0 pb-2 small text-secondary" style="border: none">{{{.}}}</li>
                         </ul>{{/description}}

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/CollectionExtensionFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/CollectionExtensionFeatures.java
@@ -64,8 +64,12 @@ public class CollectionExtensionFeatures implements CollectionExtension {
                   .itemType(featureType.getExtension(FeaturesCoreConfiguration.class)
                                        .filter(ExtensionConfiguration::isEnabled)
                                        .flatMap(FeaturesCoreConfiguration::getItemType)
-                                       .map(itemType -> itemType.toString())
+                                       .map(Enum::toString)
                                        .orElse(FeaturesCoreConfiguration.ItemType.unknown.toString()));
+
+        api.getItemCount(featureType.getId())
+            .filter(count -> count >= 0)
+            .ifPresent(count -> collection.putExtensions("itemCount", count));
 
         URICustomizer uriBuilder = uriCustomizer
                 .copy()

--- a/ogcapi-stable/ogcapi-foundation/src/main/resources/i18n-de.properties
+++ b/ogcapi-stable/ogcapi-foundation/src/main/resources/i18n-de.properties
@@ -29,6 +29,7 @@ expertInformationTitle=Weitere Details
 supportedCrsTitle=Verfügbare Referenzsysteme
 storageCrsTitle=Natives System
 itemTypeTitle=Art der Daten
+itemCountTitle=Anzahl der Objekte
 none=Keine
 keywordsTitle=Schlagworte
 moreInformation=weitere Informationen

--- a/ogcapi-stable/ogcapi-foundation/src/main/resources/i18n-en.properties
+++ b/ogcapi-stable/ogcapi-foundation/src/main/resources/i18n-en.properties
@@ -29,6 +29,7 @@ expertInformationTitle=Expert information
 supportedCrsTitle=Reference Systems
 storageCrsTitle=Storage CRS
 itemTypeTitle=Type of Data
+itemCountTitle=Number of Features
 none=None
 keywordTitles=Keywords
 moreInformation=more information


### PR DESCRIPTION
Where a count is set (and not negative) an "itemCount" member is added to the collection object in the extensions. It is also included in the HTML output.

closes #30 

@azahnen - I noticed that for more than half of the daraa collections, the value is set to -1, because of an exception when computing the count. For example, for CulturePnt. The exception is `org.postgresql.util.PSQLException: ERROR: variable not found in subplan target list`. 

