### PR TITLE
fix link to ogc_api.yml

### DIFF
--- a/demo/vineyards/README.md
+++ b/demo/vineyards/README.md
@@ -249,7 +249,7 @@ While the auto-generated API can be used as it is, the API configuration should 
 
 Updated configuration files are available here:
 
-* [`store/defaults/ogc_api.yml`](https://github.com/interactive-instruments/ldproxy/blob/master/demo/vineyards/store/defaults/ogc_api.yml)
+* [`store/defaults/ogc_api.yml`](https://github.com/interactive-instruments/ldproxy/blob/master/demo/vineyards/store/defaults/services/ogc_api.yml)
 * [`store/entities/providers/vineyards.yml`](https://github.com/interactive-instruments/ldproxy/blob/master/demo/vineyards/store/entities/providers/vineyards.yml)
 * [`store/entities/services/vineyards.yml`](https://github.com/interactive-instruments/ldproxy/blob/master/demo/vineyards/store/entities/services/vineyards.yml)
 * [`api-resources/styles/vineyards/default.mbs`](https://github.com/interactive-instruments/ldproxy/blob/master/demo/vineyards/api-resources/styles/vineyards/default.mbs)


### PR DESCRIPTION
While replicating the demo, I noticed a broken link at [Step 4](https://github.com/interactive-instruments/ldproxy/tree/master/demo/vineyards#step-4-fine-tuning-the-api-configuration)