### PR TITLE
fix plugin deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-application' version '4.1.2'
+    id 'de.interactive_instruments.xtraplatform-application' version '4.2.1'
     id 'com.github.hierynomus.license-report' version '0.16.1' apply false
     id 'com.bmuschko.docker-java-application' version '3.1.0' apply false
 }

--- a/ogcapi-draft/build.gradle
+++ b/ogcapi-draft/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-layer' version '4.1.2'
+    id 'de.interactive_instruments.xtraplatform-layer' version '4.2.1'
     id 'com.github.hierynomus.license-report' version '0.16.1' apply false
 }
 

--- a/ogcapi-stable/build.gradle
+++ b/ogcapi-stable/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-layer' version '4.1.2'
+    id 'de.interactive_instruments.xtraplatform-layer' version '4.2.1'
     id 'com.github.hierynomus.license-report' version '0.16.1' apply false
 }
 


### PR DESCRIPTION
The gradle plugin added a dependency with version `+`, which introduced a bug in master without a code change.
Since the new dynamic version did not a match another static dependency, starting ldproxy failed with `Module com.google.common` not found.
This PR removes the dynamic version and fixes the issue.