### PR TITLE
Update maven repo

### DIFF
--- a/ogcapi-draft/ogcapi-tiles/build.gradle
+++ b/ogcapi-draft/ogcapi-tiles/build.gradle
@@ -3,7 +3,7 @@ maturity = 'EXPERIMENTAL'
 
 repositories {
     maven {
-        url "https://maven.ecc.no/releases"
+        url "https://ecc-mvn.ams3.digitaloceanspaces.com/releases"
     }
 }
 


### PR DESCRIPTION
The maven repository of the java-vector-tile library was moved.
