### PR TITLE
GML: fix boolean properties

### DIFF
--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
@@ -229,7 +229,9 @@ public class GmlWriterProperties implements GmlWriter {
 
   private void writeValue(EncodingAwareContextGml context, String value, Type type) {
     if (type == Type.BOOLEAN) {
-      context.encoding().write(Boolean.parseBoolean(value));
+      context
+          .encoding()
+          .write(Boolean.parseBoolean(value) || value.equalsIgnoreCase("t") || value.equals("1"));
     } else {
       context.encoding().write(value);
     }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

This PR also maps the values "t" and "1" reported in the feature stream in the case of a Boolean property to `true`. This reflects the behavior in other feature encoders.