### PR TITLE
improve content negotiation

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiMediaType.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiMediaType.java
@@ -7,12 +7,28 @@
  */
 package de.ii.ogcapi.foundation.domain;
 
+import static javax.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import javax.ws.rs.core.MediaType;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Value.Immutable
 public interface ApiMediaType {
+
+  Logger LOGGER = LoggerFactory.getLogger(ApiMediaType.class);
+
+  enum CompatibilityLevel {
+    PARAMETERS,
+    SUBTYPES,
+    TYPES
+  }
 
   MediaType type();
 
@@ -39,6 +55,75 @@ public interface ApiMediaType {
   }
 
   default boolean matches(MediaType mediaType) {
-    return type().isCompatible(mediaType);
+    return Objects.nonNull(
+        negotiateMediaType(ImmutableList.of(type()), ImmutableList.of(mediaType)));
+  }
+
+  static boolean isCompatible(MediaType accepted, MediaType provided, CompatibilityLevel level) {
+    if (provided == null) {
+      return false;
+    }
+
+    boolean result = false;
+
+    if (level == CompatibilityLevel.TYPES
+        || level == CompatibilityLevel.SUBTYPES
+        || level == CompatibilityLevel.PARAMETERS) {
+      result =
+          accepted.getType().equals(MEDIA_TYPE_WILDCARD)
+              || provided.getType().equals(MEDIA_TYPE_WILDCARD)
+              || accepted.getType().equalsIgnoreCase(provided.getType());
+    }
+
+    if (result
+        && (level == CompatibilityLevel.SUBTYPES || level == CompatibilityLevel.PARAMETERS)) {
+      result =
+          accepted.getSubtype().equals(MEDIA_TYPE_WILDCARD)
+              || provided.getSubtype().equals(MEDIA_TYPE_WILDCARD)
+              || accepted.getSubtype().equalsIgnoreCase(provided.getSubtype())
+              || provided.getSubtype().endsWith("+" + accepted.getSubtype());
+    }
+
+    if (result && level == CompatibilityLevel.PARAMETERS) {
+      Map<String, String> acceptedParameters = accepted.getParameters();
+      Map<String, String> providedParameters = provided.getParameters();
+      result =
+          acceptedParameters.entrySet().stream()
+                  .allMatch(
+                      entry ->
+                          providedParameters.containsKey(entry.getKey())
+                              && providedParameters.get(entry.getKey()).equals(entry.getValue()))
+              && providedParameters.entrySet().stream()
+                  .allMatch(
+                      entry ->
+                          acceptedParameters.containsKey(entry.getKey())
+                              && acceptedParameters.get(entry.getKey()).equals(entry.getValue()));
+    }
+
+    return result;
+  }
+
+  static MediaType negotiateMediaType(
+      List<MediaType> acceptableMediaTypes, List<MediaType> providedMediaTypes) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("acceptable: {}", acceptableMediaTypes);
+      LOGGER.debug("provided: {}", providedMediaTypes);
+    }
+    for (CompatibilityLevel level : CompatibilityLevel.values()) {
+      for (MediaType acceptableMediaType : acceptableMediaTypes) {
+        for (MediaType providedMediaType : providedMediaTypes) {
+          if (ApiMediaType.isCompatible(acceptableMediaType, providedMediaType, level)) {
+            if (LOGGER.isDebugEnabled()) {
+              LOGGER.debug("selected: {}", providedMediaType);
+            }
+            return providedMediaType;
+          }
+        }
+      }
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("selected: null");
+    }
+    return null;
   }
 }

--- a/ogcapi-stable/ogcapi-foundation/src/test/groovy/de/ii/ogcapi/foundation/infra/rest/ContentNegotiationSpec.groovy
+++ b/ogcapi-stable/ogcapi-foundation/src/test/groovy/de/ii/ogcapi/foundation/infra/rest/ContentNegotiationSpec.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.foundation.infra.rest
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import de.ii.ogcapi.foundation.domain.ApiMediaType
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.ws.rs.core.MediaType
+
+class ContentNegotiationSpec extends Specification {
+
+    @Shared MediaType wildcard
+    @Shared MediaType image
+    @Shared MediaType png
+    @Shared MediaType application
+    @Shared MediaType json
+    @Shared MediaType jsonfg
+    @Shared MediaType jsonfgc
+    @Shared MediaType geojson
+    @Shared MediaType text
+    @Shared MediaType html
+    @Shared MediaType xml
+
+    def setupSpec() {
+        wildcard = new MediaType("*", "*")
+        text = new MediaType("text", "*")
+        html = new MediaType("text", "html")
+        image = new MediaType("image", "*")
+        png = new MediaType("image", "png")
+        application = new MediaType("application", "*")
+        xml = new MediaType("application", "xml")
+        json = new MediaType("application", "json")
+        geojson = new MediaType("application", "geo+json")
+        jsonfg = new MediaType("application", "vnd.ogc.fg+json")
+        jsonfgc = new MediaType("application", "vnd.ogc.fg+json", ImmutableMap.of("compatibility", "geojson"))
+    }
+
+    def "Negotiate with wildcard"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(wildcard)
+        List<MediaType> provided = ImmutableList.of(html, json)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && (mediaType == html || mediaType == json)
+    }
+
+    def "Negotiate with wildcard / null"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(wildcard)
+        List<MediaType> provided = ImmutableList.of()
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType == null
+    }
+
+    def "Negotiate with subtype wildcard"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(application)
+        List<MediaType> provided = ImmutableList.of(html, json, png)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && mediaType == json
+    }
+
+    def "Negotiate with subtype wildcards"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(application, image)
+        List<MediaType> provided = ImmutableList.of(html, json, png)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && (mediaType == json || mediaType == png)
+    }
+
+    def "Negotiate with subtype wildcard / null "() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(application)
+        List<MediaType> provided = ImmutableList.of(html)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType == null
+    }
+
+    def "Negotiate with subtype"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(json, xml)
+        List<MediaType> provided = ImmutableList.of(html, json, png)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && mediaType == json
+    }
+
+    def "Negotiate with subtypes"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(json, xml, png)
+        List<MediaType> provided = ImmutableList.of(html, json, png)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && (mediaType == json || mediaType == png)
+    }
+
+    def "Negotiate with subtypes / null"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(json, xml, png)
+        List<MediaType> provided = ImmutableList.of(html)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType == null
+    }
+
+    def "Negotiate with + subtype"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(xml, json)
+        List<MediaType> provided = ImmutableList.of(html, geojson, jsonfg, jsonfgc)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && (mediaType == jsonfg || mediaType == geojson || mediaType == jsonfgc)
+    }
+
+    def "Negotiate with + subtype / null"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(xml, json)
+        List<MediaType> provided = ImmutableList.of(html, geojson, jsonfg, jsonfgc)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && (mediaType == jsonfg || mediaType == geojson || mediaType == jsonfgc)
+    }
+
+    def "Negotiate with (no) parameters"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(jsonfg)
+        List<MediaType> provided = ImmutableList.of(geojson, jsonfg, jsonfgc)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && mediaType == jsonfg
+    }
+    def "Negotiate with parameters"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(jsonfgc)
+        List<MediaType> provided = ImmutableList.of(geojson, jsonfg, jsonfgc)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && mediaType == jsonfgc
+    }
+    def "Negotiate with parameters, fallback"() {
+        given:
+        List<MediaType> acceptable = ImmutableList.of(jsonfgc)
+        List<MediaType> provided = ImmutableList.of(geojson, jsonfg)
+        when:
+        MediaType mediaType = ApiMediaType.negotiateMediaType(acceptable, provided)
+        then:
+        mediaType != null && mediaType == jsonfg
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

This PR makes content negotiation for the media type more robust. In particular, content negotiation now supports media type parameters. This PR is required, for example, for the GeoJSON compatibility mode of JSON-FG added by #758.