### PR TITLE
bbox parameter: make property configurable

### DIFF
--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
@@ -130,6 +130,16 @@ public interface FeaturesCoreConfiguration
   }
 
   /**
+   * @langEn Name of the property to use for the bbox query parameter. The default value is the
+   *     primary geometry property.
+   * @langDe Name der Eigenschaft, die für den bbox-Query-Parameter verwendet werden soll. Der
+   *     Standardwert ist die primäre Geometrieeigenschaft.
+   * @default `{}`
+   */
+  @Nullable
+  String getBboxProperty();
+
+  /**
    * @langEn Default coordinate reference system, either `CRS84` for datasets with 2D geometries or
    *     `CRS84h` for datasets with 3D geometries.
    * @langDe Setzt das Standard-Koordinatenreferenzsystem, entweder 'CRS84' für einen Datensatz mit


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

- [x] Add new configuration option `bboxProperty` in Features Core to identify a specific property to use for the "bbox" query parameter.
- [ ] Add new configuration option `datetimeProperties` in Features Core to identify a specific property to use for the "datetime" query parameter (instant or interval from two instants, or "null" for unbounded interval ends).