### PR TITLE
Geometry improvements to the feature encodings with flat attributes (mvt, fgb)

### DIFF
--- a/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureEncoderFlatgeobuf.java
+++ b/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureEncoderFlatgeobuf.java
@@ -66,6 +66,7 @@ public class FeatureEncoderFlatgeobuf extends FeatureObjectEncoder<PropertySfFla
   private final FeatureSchema featureSchema;
   private final OutputStream outputStream;
   private final FlatBufferBuilder builder;
+  private final List<String> geometryProperty;
   private HeaderMeta headerMeta;
 
   private final long transformerStart;
@@ -90,6 +91,7 @@ public class FeatureEncoderFlatgeobuf extends FeatureObjectEncoder<PropertySfFla
     this.geometryFactory = new GeometryFactory();
     this.builder = new FlatBufferBuilder(16 * 1024); // 16kB
     this.transformerStart = System.nanoTime();
+    this.geometryProperty = encodingContext.getGeometryProperty();
   }
 
   @Override
@@ -132,7 +134,8 @@ public class FeatureEncoderFlatgeobuf extends FeatureObjectEncoder<PropertySfFla
     long startFeature = System.nanoTime();
 
     try {
-      Geometry currentGeometry = feature.getJtsGeometry(geometryFactory).orElse(null);
+      Geometry currentGeometry =
+          feature.getJtsGeometry(geometryProperty, geometryFactory).orElse(null);
 
       final int propertiesOffset = addProperties(feature.getPropertiesAsMap());
 

--- a/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureEncoderFlatgeobuf.java
+++ b/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureEncoderFlatgeobuf.java
@@ -42,6 +42,7 @@ import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.util.GeometryFixer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wololo.flatgeobuf.ColumnMeta;
@@ -136,6 +137,11 @@ public class FeatureEncoderFlatgeobuf extends FeatureObjectEncoder<PropertySfFla
     try {
       Geometry currentGeometry =
           feature.getJtsGeometry(geometryProperty, geometryFactory).orElse(null);
+
+      // fix invalid source geometries
+      if (Objects.nonNull(currentGeometry) && !currentGeometry.isValid()) {
+        currentGeometry = new GeometryFixer(currentGeometry).getResult();
+      }
 
       final int propertiesOffset = addProperties(feature.getPropertiesAsMap());
 

--- a/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureTransformationContextFlatgeobuf.java
+++ b/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeatureTransformationContextFlatgeobuf.java
@@ -9,6 +9,7 @@ package de.ii.ogcapi.features.flatgeobuf.app;
 
 import de.ii.ogcapi.features.core.domain.FeatureTransformationContext;
 import de.ii.xtraplatform.features.domain.FeatureSchema;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -19,4 +20,6 @@ public abstract class FeatureTransformationContextFlatgeobuf
   public abstract FeatureSchema getSchema();
 
   public abstract boolean getIs3d();
+
+  public abstract List<String> getGeometryProperty();
 }

--- a/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeaturesFormatFlatgeobuf.java
+++ b/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeaturesFormatFlatgeobuf.java
@@ -142,6 +142,11 @@ public class FeaturesFormatFlatgeobuf implements ConformanceClass, FeatureFormat
                 .from(transformationContext)
                 .schema(schema)
                 .is3d(crsInfo.is3d(crs))
+                .geometryProperty(
+                    apiData
+                        .getExtension(FlatgeobufConfiguration.class, collectionId)
+                        .map(FlatgeobufConfiguration::getGeometryProperty)
+                        .orElse(ImmutableList.of()))
                 .build()));
   }
 }

--- a/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/domain/FlatgeobufConfiguration.java
+++ b/ogcapi-draft/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/domain/FlatgeobufConfiguration.java
@@ -10,6 +10,7 @@ package de.ii.ogcapi.features.flatgeobuf.domain;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
@@ -17,6 +18,17 @@ import org.immutables.value.Value;
 @Value.Style(builder = "new", deepImmutablesDetection = true, attributeBuilderDetection = true)
 @JsonDeserialize(builder = ImmutableFlatgeobufConfiguration.Builder.class)
 public interface FlatgeobufConfiguration extends ExtensionConfiguration, PropertyTransformations {
+
+  /**
+   * @langEn Name of the property to use for the geometry. Multiple properties can be provided, the
+   *     first property that has a value is used. The default value is the primary geometry
+   *     property.
+   * @langDe Name der Eigenschaft, die für die Geometrie verwendet werden soll. Es können mehrere
+   *     Eigenschaften angegeben werden; die erste Eigenschaft, die einen Wert hat, wird verwendet.
+   *     Der Standardwert ist die primäre Geometrieeigenschaft.
+   * @default `{}`
+   */
+  List<String> getGeometryProperty();
 
   /**
    * @return If the data is flattened and the feature schema includes arrays, {@code

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/FeatureEncoderMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/FeatureEncoderMVT.java
@@ -57,6 +57,7 @@ public class FeatureEncoderMVT extends FeatureObjectEncoder<PropertySfFlat, Feat
   private final Polygon clipGeometry;
   private final List<String> groupBy;
   private final Set<MvtFeature> mergeFeatures;
+  private final List<String> geometryProperty;
 
   private long mergeCount = 0;
   private final long transformerStart = System.nanoTime();
@@ -92,6 +93,7 @@ public class FeatureEncoderMVT extends FeatureObjectEncoder<PropertySfFlat, Feat
     coords[3] = new CoordinateXY(-buffer, -buffer);
     coords[4] = coords[0];
     this.clipGeometry = geometryFactoryTile.createPolygon(coords);
+    this.geometryProperty = encodingContext.getGeometryProperty();
 
     final Map<String, List<Rule>> rules = tilesConfiguration.getRulesDerived();
     this.groupBy =
@@ -138,7 +140,8 @@ public class FeatureEncoderMVT extends FeatureObjectEncoder<PropertySfFlat, Feat
     if (Objects.isNull(featureStart)) featureStart = System.nanoTime();
     featureCount++;
 
-    Optional<Geometry> featureGeometry = feature.getJtsGeometry(geometryFactoryWorld);
+    Optional<Geometry> featureGeometry =
+        feature.getJtsGeometry(geometryProperty, geometryFactoryWorld);
 
     if (featureGeometry.isEmpty()) {
       return;

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileProviderFeatures.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileProviderFeatures.java
@@ -111,6 +111,17 @@ public abstract class TileProviderFeatures extends TileProvider {
   public abstract Map<String, MinMax> getSeeding();
 
   /**
+   * @langEn Name of the property to use for the geometry. Multiple properties can be provided, the
+   *     first property that has a value is used. The default value is the primary geometry
+   *     property.
+   * @langDe Name der Eigenschaft, die für die Geometrie verwendet werden soll. Es können mehrere
+   *     Eigenschaften angegeben werden; die erste Eigenschaft, die einen Wert hat, wird verwendet.
+   *     Der Standardwert ist die primäre Geometrieeigenschaft.
+   * @default `{}`
+   */
+  public abstract List<String> getGeometryProperty();
+
+  /**
    * @langEn Filters to select a subset of feature for certain zoom levels using a CQL filter
    *     expression, see example below.
    * @langDe Über Filter kann gesteuert werden, welche Features auf welchen Zoomstufen selektiert
@@ -395,6 +406,9 @@ public abstract class TileProviderFeatures extends TileProvider {
         ImmutableTileProviderFeatures.builder().from((TileProviderFeatures) source).from(this);
 
     TileProviderFeatures src = (TileProviderFeatures) source;
+
+    builder.geometryProperty(
+        !getGeometryProperty().isEmpty() ? getGeometryProperty() : src.getGeometryProperty());
 
     List<String> tileEncodings =
         Objects.nonNull(src.getTileEncodings())

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/FeatureTransformationContextTiles.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/FeatureTransformationContextTiles.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.tiles.domain;
 
 import de.ii.ogcapi.features.core.domain.FeatureTransformationContext;
+import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -20,6 +21,8 @@ public interface FeatureTransformationContextTiles extends FeatureTransformation
   Tile tile();
 
   TileCache getTileCache();
+
+  List<String> getGeometryProperty();
 
   @Value.Lazy
   default TilesConfiguration tilesConfiguration() {


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Update the MVT and FlatGeobuf formats:

- support a configuration option `geometryProperty` to use a geometry property that is not the primary one
- try to make invalid geometries valid

Depends on changes in the `bbox-property` branch.

Potentially split into two pull requests and separate the changes that try to make invalid geometries valid. This does not depend on the bbox-property changes.