### PR TITLE
update GML to support CityGML

### DIFF
--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
@@ -7,6 +7,8 @@
  */
 package de.ii.ogcapi.features.gml.app;
 
+import static de.ii.ogcapi.features.gml.domain.GmlConfiguration.GmlVersion.GML32;
+
 import com.github.azahnen.dagger.annotations.AutoBind;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -61,11 +63,15 @@ import javax.ws.rs.core.MediaType;
 public class FeaturesFormatGml implements ConformanceClass, FeatureFormatExtension {
 
   private static final String XML = "xml";
+  private static final String GML21 = "gml21";
+  private static final String GML31 = "gml31";
   private static final String GML = "gml";
   private static final String XLINK = "xlink";
   private static final String XSI = "xsi";
   private static final String SF = "sf";
   private static final String WFS = "wfs";
+  private static final String GML21_NS = "http://www.opengis.net/gml";
+  private static final String GML31_NS = "http://www.opengis.net/gml";
   private static final String GML_NS = "http://www.opengis.net/gml/3.2";
   private static final String XLINK_NS = "http://www.w3.org/1999/xlink";
   private static final String XML_NS = "http://www.w3.org/XML/1998/namespace";
@@ -74,16 +80,21 @@ public class FeaturesFormatGml implements ConformanceClass, FeatureFormatExtensi
   private static final String WFS_NS = "http://www.opengis.net/wfs/2.0";
   private static final Map<String, String> STANDARD_NAMESPACES =
       ImmutableMap.of(
-          GML, GML_NS, XLINK, XLINK_NS, XML, XML_NS, XSI, XSI_NS, SF, SF_NS, WFS, WFS_NS);
+          GML, GML_NS, GML21, GML21_NS, GML31, GML31_NS, XLINK, XLINK_NS, XML, XML_NS, XSI, XSI_NS,
+          SF, SF_NS, WFS, WFS_NS);
 
   private static final String GML_XSD = "http://schemas.opengis.net/gml/3.2.1/gml.xsd";
+  private static final String GML21_XSD = "https://schemas.opengis.net/gml/2.1.2/gml.xsd";
+  private static final String GML31_XSD = "https://schemas.opengis.net/gml/3.1.1/base/gml.xsd";
   private static final String XLINK_XSD = "http://www.w3.org/1999/xlink.xsd";
   private static final String XML_XSD = "http://www.w3.org/2001/xml.xsd";
   private static final String SF_XSD =
       "http://schemas.opengis.net/ogcapi/features/part1/1.0/xml/core-sf.xsd";
   private static final String WFS_XSD = "http://schemas.opengis.net/wfs/2.0/wfs.xsd";
   private static final Map<String, String> STANDARD_SCHEMA_LOCATIONS =
-      ImmutableMap.of(GML, GML_XSD, XLINK, XLINK_XSD, XML, XML_XSD, SF, SF_XSD, WFS, WFS_XSD);
+      ImmutableMap.of(
+          GML, GML_XSD, GML31, GML31_XSD, GML21, GML21_XSD, XLINK, XLINK_XSD, XML, XML_XSD, SF,
+          SF_XSD, WFS, WFS_XSD);
 
   private static final String GML_UPPERCASE = "GML";
   private static final String APPLICATION = "application";
@@ -188,6 +199,7 @@ public class FeaturesFormatGml implements ConformanceClass, FeatureFormatExtensi
     return Conformance.NONE;
   }
 
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private Conformance getConformance(Optional<GmlConfiguration> configuration) {
     return configuration
         .filter(c -> !SF_FEATURE_COLLECTION.equals(c.getFeatureCollectionElementName()))
@@ -337,6 +349,7 @@ public class FeaturesFormatGml implements ConformanceClass, FeatureFormatExtensi
     ImmutableFeatureTransformationContextGml transformationContextGml =
         ImmutableFeatureTransformationContextGml.builder()
             .from(transformationContext)
+            .gmlVersion(Objects.requireNonNullElse(config.getGmlVersion(), GML32))
             .putAllNamespaces(config.getApplicationNamespaces())
             .putAllNamespaces(STANDARD_NAMESPACES)
             .defaultNamespace(Optional.ofNullable(config.getDefaultNamespace()))

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterSkeleton.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterSkeleton.java
@@ -7,6 +7,9 @@
  */
 package de.ii.ogcapi.features.gml.app;
 
+import static de.ii.ogcapi.features.gml.domain.GmlConfiguration.GmlVersion.GML21;
+import static de.ii.ogcapi.features.gml.domain.GmlConfiguration.GmlVersion.GML31;
+import static de.ii.ogcapi.features.gml.domain.GmlConfiguration.GmlVersion.GML32;
 import static de.ii.xtraplatform.base.domain.util.LambdaWithException.consumerMayThrow;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
@@ -94,7 +97,9 @@ public class GmlWriterSkeleton implements GmlWriter {
     String elementName = context.encoding().startGmlObject(context.schema().orElseThrow());
     context.encoding().write("<");
     context.encoding().write(elementName);
-    context.encoding().write(" gml:id=\"");
+    context.encoding().write(" ");
+    context.encoding().write(context.encoding().getGmlPrefix());
+    context.encoding().write(":id=\"");
     context.encoding().writeGmlIdPlaceholder();
     context.encoding().write("\"");
     context.encoding().writeXmlAttPlaceholder();
@@ -165,7 +170,13 @@ public class GmlWriterSkeleton implements GmlWriter {
             .filter(
                 entry ->
                     (!"sf".equals(entry.getKey()) || rootElement.startsWith("sf:"))
-                        && (!"wfs".equals(entry.getKey()) || rootElement.startsWith("wfs:")))
+                        && (!"wfs".equals(entry.getKey()) || rootElement.startsWith("wfs:"))
+                        && (!"gml21".equals(entry.getKey())
+                            || context.encoding().getGmlVersion().equals(GML21))
+                        && (!"gml31".equals(entry.getKey())
+                            || context.encoding().getGmlVersion().equals(GML31))
+                        && (!"gml".equals(entry.getKey())
+                            || context.encoding().getGmlVersion().equals(GML32)))
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
     XMLNamespaceNormalizer namespaceNormalizer = new XMLNamespaceNormalizer(effectiveNamespaces);

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
@@ -7,6 +7,8 @@
  */
 package de.ii.ogcapi.features.gml.domain;
 
+import static de.ii.ogcapi.features.gml.domain.GmlConfiguration.GmlVersion.GML32;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
@@ -56,11 +58,35 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = ImmutableGmlConfiguration.Builder.class)
 public interface GmlConfiguration extends ExtensionConfiguration, PropertyTransformations {
 
+  enum GmlVersion {
+    GML21,
+    GML31,
+    GML32
+  }
+
   enum Conformance {
     NONE,
     GMLSF0,
     GMLSF2
   }
+
+  /**
+   * @langEn Selects the GML version to use: `GML32` for GML 3.2, `GML31` for GML 3.1 and `GML21`
+   *     for GML 2.1.
+   * @langDe Bestimmt die zu verwendende GML-Version: `GML32` für GML 3.2, `GML31` für GML 3.1 und
+   *     `GML21` für GML 2.1.
+   * @default `GML32`
+   * @example <code>
+   * ```yaml
+   * - buildingBlock: GML
+   *   enabled: true
+   *   gmlVersion: GML31
+   * ```
+   * </code>
+   * @since v3.3
+   */
+  @Nullable
+  GmlVersion getGmlVersion();
 
   /**
    * @langEn The default `null` declares that the GML support does not meet all requirements of the
@@ -98,6 +124,10 @@ public interface GmlConfiguration extends ExtensionConfiguration, PropertyTransf
 
   @Value.Derived
   default Conformance getConformance() {
+    if (!Objects.requireNonNullElse(getGmlVersion(), GML32).equals(GML32)) {
+      return Conformance.NONE;
+    }
+
     switch (Objects.requireNonNullElse(getGmlSfLevel(), -1)) {
       case 0:
         return Conformance.GMLSF0;

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.1.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.1.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.1.0-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.1.0-geometry-constraints-SNAPSHOT'
 }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

* support for GML 3.1 (and GML 2.1)
* support for geometry constraints 'composite', 'closed' and mappings to gml:CompositeCurve, gml:CompositeSurface and gml:Solid
* support for cases where a 'rename' transformation needs to provide two name components (in CityGML for generic attributes)
* special treatment to support the links from the lod2Solid of a CityGML building to the polygons in its boundary surfaces
