### PR TITLE
improve handling of LoD2 buildings without a boundary surface

### DIFF
--- a/ogcapi-draft/ogcapi-features-cityjson/src/main/java/de/ii/ogcapi/features/cityjson/app/CityJsonWriterGeometry.java
+++ b/ogcapi-draft/ogcapi-features-cityjson/src/main/java/de/ii/ogcapi/features/cityjson/app/CityJsonWriterGeometry.java
@@ -159,17 +159,13 @@ public class CityJsonWriterGeometry implements CityJsonWriter {
       EncodingAwareContextCityJson context, Consumer<EncodingAwareContextCityJson> next)
       throws IOException {
 
-    try {
-      if (context.getState().inSection() == Section.WAITING_FOR_SURFACES) {
-        // No surfaces found, close geometry object
-        TokenBuffer buffer = context.getState().getGeometryBuffer().get();
-        buffer.writeEndObject();
-      }
-
-      context.encoding().stopAndFlushGeometry();
-    } catch (com.fasterxml.jackson.core.JsonGenerationException e) {
-      LOGGER.error("{} {}", context.getState().getCurrentId(), context.encoding().getJson());
+    if (context.getState().inSection() == Section.WAITING_FOR_SURFACES) {
+      // No surfaces found, close geometry object
+      TokenBuffer buffer = context.getState().getGeometryBuffer().get();
+      buffer.writeEndObject();
     }
+
+    context.encoding().stopAndFlushGeometry();
 
     next.accept(context);
   }

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
@@ -19,6 +19,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({
   "ConstantConditions",
@@ -27,6 +29,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true)
 public abstract class FeatureTransformationContextGml implements FeatureTransformationContext {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(FeatureTransformationContextGml.class);
 
   private static final String XML_ATTRIBUTE_PLACEHOLDER = "_$$_XML_ATTRIBUTE_i_$$_";
   private static final String GML_ID_PLACEHOLDER = "_$$_GML_ID_i_$$_";
@@ -111,6 +116,11 @@ public abstract class FeatureTransformationContextGml implements FeatureTransfor
           .getPlaceholders()
           .forEach(
               (key, value) -> {
+                // Most placeholders cannot be empty - if they are, there is an error that
+                // should be reported
+                if (!key.startsWith("_$$_XML_ATTRIBUTE_") && value.isEmpty()) {
+                  return;
+                }
                 // variable object elements appear twice - opening and closing tag
                 IntStream.rangeClosed(1, 2)
                     .forEach(
@@ -122,13 +132,18 @@ public abstract class FeatureTransformationContextGml implements FeatureTransfor
                         });
               });
 
-      if (buffer.lastIndexOf("_$$_") != -1) {
-        throw new IllegalStateException(
-            String.format("GML feature buffer contains unresolved placeholders: %s", buffer));
+      if (buffer.indexOf("_$$_") == -1) {
+        // write buffer
+        getOutputStream().write(buffer.toString().getBytes());
+      } else {
+        if (LOGGER.isErrorEnabled()) {
+          LOGGER.error(
+              "GML feature buffer for a feature contains unresolved placeholders, the feature is ignored: {}",
+              buffer.substring(0, buffer.indexOf("_$$_") + 50));
+        }
       }
 
-      // write buffer and clear the buffer and the placeholder information
-      getOutputStream().write(buffer.toString().getBytes());
+      // clear the buffer and the placeholder information
       getState().unsetPlaceholders();
       buffer.setLength(0);
     }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Buildings in LoD2 should have boundary surfaces, but in practice some buildings may not have them. This PR makes the handling more robust by detecting and handling such cases.