### PR TITLE
skip f parameter in self links, if there is no alternate link

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/DefaultLinksGenerator.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/DefaultLinksGenerator.java
@@ -29,7 +29,10 @@ public class DefaultLinksGenerator {
         new ImmutableList.Builder<Link>()
             .add(
                 new ImmutableLink.Builder()
-                    .href(uriBuilder.setParameter("f", mediaType.parameter()).toString())
+                    .href(
+                        alternateMediaTypes.isEmpty()
+                            ? uriBuilder.toString()
+                            : uriBuilder.copy().setParameter("f", mediaType.parameter()).toString())
                     .rel("self")
                     .type(mediaType.type().toString())
                     .title(i18n.get("selfLink", language))


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

In "self" links, the "f" parameter should not be set, if there is no alternate encoding (and maybe also no parameter "f").