### PR TITLE
support {serviceUrl} in API/collection descriptions

### DIFF
--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/CollectionsDataHydrator.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/app/CollectionsDataHydrator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.collections.app;
+
+import com.github.azahnen.dagger.annotations.AutoBind;
+import com.google.common.collect.ImmutableMap;
+import de.ii.ogcapi.common.domain.CommonConfiguration;
+import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
+import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.ImmutableFeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.ImmutableOgcApiDataV2;
+import de.ii.ogcapi.foundation.domain.OgcApiDataHydratorExtension;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
+import de.ii.xtraplatform.services.domain.ServicesContext;
+import java.net.URI;
+import java.util.AbstractMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@AutoBind
+public class CollectionsDataHydrator implements OgcApiDataHydratorExtension {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CollectionsDataHydrator.class);
+
+  private final URI servicesUri;
+
+  @Inject
+  public CollectionsDataHydrator(ServicesContext servicesContext) {
+    this.servicesUri = servicesContext.getUri();
+  }
+
+  @Override
+  public int getSortPriority() {
+    return 50;
+  }
+
+  @Override
+  public Class<? extends ExtensionConfiguration> getBuildingBlockConfigurationType() {
+    return CommonConfiguration.class;
+  }
+
+  @Override
+  public OgcApiDataV2 getHydratedData(OgcApiDataV2 apiData) {
+
+    OgcApiDataV2 data = apiData;
+
+    // replace {serviceUrl} in collection descriptions
+    data =
+        new ImmutableOgcApiDataV2.Builder()
+            .from(data)
+            .collections(
+                data.getCollections().entrySet().stream()
+                    .map(
+                        entry -> {
+                          final String collectionId = entry.getKey();
+                          if (entry.getValue().getDescription().isEmpty()
+                              || !entry
+                                  .getValue()
+                                  .getDescription()
+                                  .get()
+                                  .contains("{serviceUrl}")) {
+                            return entry;
+                          }
+
+                          return new AbstractMap.SimpleImmutableEntry<
+                              String, FeatureTypeConfigurationOgcApi>(
+                              collectionId,
+                              new ImmutableFeatureTypeConfigurationOgcApi.Builder()
+                                  .from(entry.getValue())
+                                  .description(
+                                      entry
+                                          .getValue()
+                                          .getDescription()
+                                          .map(
+                                              desc ->
+                                                  desc.replace(
+                                                      "{serviceUrl}", servicesUri.toString())))
+                                  .build());
+                        })
+                    .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
+            .build();
+
+    return data;
+  }
+}

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/CommonDataHydrator.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/CommonDataHydrator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.common.app;
+
+import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.ogcapi.common.domain.CommonConfiguration;
+import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
+import de.ii.ogcapi.foundation.domain.ImmutableOgcApiDataV2;
+import de.ii.ogcapi.foundation.domain.OgcApiDataHydratorExtension;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
+import de.ii.xtraplatform.services.domain.ServicesContext;
+import java.net.URI;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@AutoBind
+public class CommonDataHydrator implements OgcApiDataHydratorExtension {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommonDataHydrator.class);
+
+  private final URI servicesUri;
+
+  @Inject
+  public CommonDataHydrator(ServicesContext servicesContext) {
+    this.servicesUri = servicesContext.getUri();
+  }
+
+  @Override
+  public int getSortPriority() {
+    return 50;
+  }
+
+  @Override
+  public Class<? extends ExtensionConfiguration> getBuildingBlockConfigurationType() {
+    return CommonConfiguration.class;
+  }
+
+  @Override
+  public OgcApiDataV2 getHydratedData(OgcApiDataV2 apiData) {
+
+    if (apiData.getDescription().isEmpty()
+        || !apiData.getDescription().get().contains("{serviceUrl}")) {
+      return apiData;
+    }
+
+    OgcApiDataV2 data = apiData;
+
+    // replace {serviceUrl} in API descriptions
+    data =
+        new ImmutableOgcApiDataV2.Builder()
+            .from(data)
+            .description(
+                data.getDescription()
+                    .map(desc -> desc.replace("{serviceUrl}", servicesUri.toString())))
+            .build();
+
+    return data;
+  }
+}


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

It can useful to include links into the API in the description of a API or collection. This requires support for replacing the "{serviceUrl}" template in the description to adapt to different deployment URLs.