### PR TITLE
fix xtraplatform-spatial dependency

### DIFF
--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.1.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.1.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.1.0-geometry-constraints-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.1.0-SNAPSHOT'
 }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

The xtraplatform-spatial dependency was outdated to a branch (that has been merged) instead of master.