### PR TITLE
Add option to omit large Link header

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiRequestContext.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiRequestContext.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import javax.ws.rs.core.Request;
+import org.immutables.value.Value;
 
 public interface ApiRequestContext {
   ApiMediaType getMediaType();
@@ -29,4 +30,9 @@ public interface ApiRequestContext {
   Map<String, String> getParameters();
 
   Optional<Request> getRequest();
+
+  @Value.Default
+  default int getMaxResponseLinkHeaderSize() {
+    return 2048;
+  }
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/FoundationConfiguration.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/FoundationConfiguration.java
@@ -88,19 +88,6 @@ public interface FoundationConfiguration extends ExtensionConfiguration {
   Boolean getIncludeLinkHeader();
 
   /**
-   * @langEn Return the Link HTTP headers only if the size of the Link is not larger than the limit.
-   *     The value is in bytes, e.g. 2048 would be 2 kB. Large HTTP headers increase the size of the
-   *     response and may cause an exception in Dropwizard.
-   * @langDe Steuert, dass die Link-HTTP-Header nur zurückgegeben werden, wenn die Länge der Links
-   *     nicht größer als das Limit in Bytes ist (2048 wären 2 kB). Große HTTP-Header können die
-   *     Größe der Antwort unverhältnismäßig erhöhen und die können zu einer Dropwizard-Exception
-   *     führen.
-   * @default `null`
-   */
-  @Nullable
-  Integer getLinkHeaderLengthLimit();
-
-  /**
    * @langEn Title for resource *API Catalog*.
    * @langDe Titel für die API-Catalog-Ressource in diesem Deployment.
    * @default "API Overview"

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/FoundationConfiguration.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/FoundationConfiguration.java
@@ -88,6 +88,19 @@ public interface FoundationConfiguration extends ExtensionConfiguration {
   Boolean getIncludeLinkHeader();
 
   /**
+   * @langEn Return the Link HTTP headers only if the size of the Link is not larger than the limit.
+   *     The value is in bytes, e.g. 2048 would be 2 kB. Large HTTP headers increase the size of the
+   *     response and may cause an exception in Dropwizard.
+   * @langDe Steuert, dass die Link-HTTP-Header nur zurückgegeben werden, wenn die Länge der Links
+   *     nicht größer als das Limit in Bytes ist (2048 wären 2 kB). Große HTTP-Header können die
+   *     Größe der Antwort unverhältnismäßig erhöhen und die können zu einer Dropwizard-Exception
+   *     führen.
+   * @default `null`
+   */
+  @Nullable
+  Integer getLinkHeaderLengthLimit();
+
+  /**
    * @langEn Title for resource *API Catalog*.
    * @langDe Titel für die API-Catalog-Ressource in diesem Deployment.
    * @default "API Overview"

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueriesHandler.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.InternalServerErrorException;
@@ -137,16 +136,9 @@ public interface QueriesHandler<T extends QueryIdentifier> {
               .map(Link::getLink)
               .collect(Collectors.toUnmodifiableList());
 
-      // only add links, if the Link strings are not larger than the limit, if one is provided
-      Optional<Integer> optionalLimit =
-          requestContext
-              .getApi()
-              .getData()
-              .getExtension(FoundationConfiguration.class)
-              .map(FoundationConfiguration::getLinkHeaderLengthLimit);
-      if (optionalLimit.isEmpty()
-          || headerLinks.stream().map(l -> l.toString().length()).mapToInt(Integer::intValue).sum()
-              <= optionalLimit.get()) {
+      // only add links, if the Link strings are not larger than the limit
+      if (headerLinks.stream().map(l -> l.toString().length()).mapToInt(Integer::intValue).sum()
+          <= requestContext.getMaxResponseLinkHeaderSize()) {
         headerLinks.forEach(response::links);
       }
     }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Large HTTP headers increase the size of the response and may cause an exception in dropwizard. This adds a `linkHeaderLengthLimit` option to omit the Link header, if the text length of the link is larger than the limit.

No default limit value is set for backwards compatibility. In version 4.0 we should consider to set a default limit.