### PR TITLE
fix ApiMediaType::matches

### DIFF
--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/app/StyleRepositoryFiles.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/app/StyleRepositoryFiles.java
@@ -419,11 +419,12 @@ public class StyleRepositoryFiles implements StyleRepository, AppLifeCycle {
         if (collectionId.isPresent())
           throw new NotAcceptableException(
               MessageFormat.format(
-                  "The style ''{0}'' is not available in the requested format for collection ''{1}''.",
-                  styleId, collectionId.get()));
+                  "The style ''{0}'' is not available in the requested format ''{{1}}'' for collection ''{2}''.",
+                  styleId, styleFormat.getMediaType().label(), collectionId.get()));
         throw new NotAcceptableException(
             MessageFormat.format(
-                "The style ''{0}'' is not available in the requested format.", styleId));
+                "The style ''{0}'' is not available in the requested format ''{1}''.",
+                styleId, styleFormat.getMediaType().label()));
       }
 
       if (collectionId.isPresent())

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiMediaType.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiMediaType.java
@@ -9,11 +9,9 @@ package de.ii.ogcapi.foundation.domain;
 
 import static javax.ws.rs.core.MediaType.MEDIA_TYPE_WILDCARD;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import javax.ws.rs.core.MediaType;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -55,8 +53,7 @@ public interface ApiMediaType {
   }
 
   default boolean matches(MediaType mediaType) {
-    return Objects.nonNull(
-        negotiateMediaType(ImmutableList.of(type()), ImmutableList.of(mediaType)));
+    return ApiMediaType.isCompatible(mediaType, this.type(), CompatibilityLevel.PARAMETERS);
   }
 
   static boolean isCompatible(MediaType accepted, MediaType provided, CompatibilityLevel level) {


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

ApiMediaType::matches used content negotiation, but must just check compatibility, including parameters (which MediaType::isCompatible ignores). The target media type has already been negotiated.

This is a follow-up to #759. Before that pull request, the behaviour was stricter.

The pull request also improves a related error message.
