### PR TITLE
Tile improvements

### DIFF
--- a/ogcapi-draft/ogcapi-maps/src/main/java/de/ii/ogcapi/maps/app/MapTileSetsFormatHtml.java
+++ b/ogcapi-draft/ogcapi-maps/src/main/java/de/ii/ogcapi/maps/app/MapTileSetsFormatHtml.java
@@ -137,9 +137,6 @@ public class MapTileSetsFormatHtml implements TileSetsFormatExtension {
     return new TileSetsView(
         api.getData(),
         tiles,
-        collectionId,
-        api.getSpatialExtent(collectionId),
-        api.getTemporalExtent(collectionId),
         tileMatrixSets,
         breadCrumbs,
         requestContext.getStaticUrlPrefix(),
@@ -148,7 +145,6 @@ public class MapTileSetsFormatHtml implements TileSetsFormatExtension {
         false,
         htmlConfig.orElseThrow(),
         isNoIndexEnabledForApi(api.getData()),
-        requestContext.getUriCustomizer(),
         i18n,
         requestContext.getLanguage());
   }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesDataHydrator.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesDataHydrator.java
@@ -242,6 +242,7 @@ public class TilesDataHydrator implements OgcApiDataHydratorExtension {
                           .tileEncoding(format)
                           .center(center)
                           .bounds(bounds)
+                          .vectorLayers(metadata.getVectorLayers())
                           .build())
                   .build();
         } catch (Exception e) {

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/html/TileSetsFormatHtml.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/html/TileSetsFormatHtml.java
@@ -163,9 +163,6 @@ public class TileSetsFormatHtml implements TileSetsFormatExtension {
     return new TileSetsView(
         api.getData(),
         tiles,
-        collectionId,
-        api.getSpatialExtent(collectionId),
-        api.getTemporalExtent(collectionId),
         tileMatrixSets,
         breadCrumbs,
         requestContext.getStaticUrlPrefix(),
@@ -174,7 +171,6 @@ public class TileSetsFormatHtml implements TileSetsFormatExtension {
         removeZoomLevelConstraints,
         htmlConfig.orElseThrow(),
         isNoIndexEnabledForApi(api.getData()),
-        requestContext.getUriCustomizer(),
         i18n,
         requestContext.getLanguage());
   }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileProviderMbtiles.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileProviderMbtiles.java
@@ -87,6 +87,9 @@ public abstract class TileProviderMbtiles extends TileProvider {
   @JsonIgnore
   public abstract Optional<BoundingBox> getBounds();
 
+  @JsonIgnore
+  public abstract List<VectorLayer> getVectorLayers();
+
   @Override
   @JsonIgnore
   @Value.Default

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileSetsView.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileSetsView.java
@@ -17,8 +17,6 @@ import de.ii.ogcapi.foundation.domain.I18n;
 import de.ii.ogcapi.foundation.domain.Link;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.foundation.domain.OgcResourceMetadata;
-import de.ii.ogcapi.foundation.domain.TemporalExtent;
-import de.ii.ogcapi.foundation.domain.URICustomizer;
 import de.ii.ogcapi.html.domain.HtmlConfiguration;
 import de.ii.ogcapi.html.domain.ImmutableMapClient;
 import de.ii.ogcapi.html.domain.ImmutableSource;
@@ -33,6 +31,7 @@ import de.ii.ogcapi.tilematrixsets.domain.TileMatrixSet;
 import de.ii.ogcapi.tiles.domain.TileLayer.GeometryType;
 import de.ii.ogcapi.tiles.domain.TileSet.DataType;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
+import de.ii.xtraplatform.crs.domain.OgcCrs;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
 import java.util.List;
@@ -72,9 +71,6 @@ public class TileSetsView extends OgcApiView {
   public TileSetsView(
       OgcApiDataV2 apiData,
       TileSets tiles,
-      Optional<String> collectionId,
-      Optional<BoundingBox> spatialExtent,
-      Optional<TemporalExtent> temporalExtent,
       Map<String, TileMatrixSet> tileMatrixSets,
       List<NavigationDTO> breadCrumbs,
       String urlPrefix,
@@ -83,7 +79,6 @@ public class TileSetsView extends OgcApiView {
       boolean removeZoomLevelConstraints,
       HtmlConfiguration htmlConfig,
       boolean noIndex,
-      URICustomizer uriCustomizer,
       I18n i18n,
       Optional<Locale> language) {
     super(
@@ -98,10 +93,26 @@ public class TileSetsView extends OgcApiView {
         tiles.getTitle().orElse(apiData.getId()),
         tiles.getDescription().orElse(""));
 
-    Optional<BoundingBox> finalSpatialExtent =
-        spatialExtent.or(() -> apiData.getDefaultExtent().flatMap(CollectionExtent::getSpatial));
+    // the center of all tilesets is the same, the only difference is the tiling scheme
+    final Optional<TilePoint> center =
+        tiles.getTilesets().stream().findAny().flatMap(TileSet::getCenterPoint);
+
+    Optional<BoundingBox> spatialExtent =
+        tiles.getTilesets().stream()
+            .map(TileSet::getBoundingBox)
+            // the bbox of all tilesets is the same, the only difference is the tiling scheme
+            .findAny()
+            .map(
+                tBbox ->
+                    BoundingBox.of(
+                        tBbox.getLowerLeft()[0].doubleValue(),
+                        tBbox.getLowerLeft()[1].doubleValue(),
+                        tBbox.getUpperRight()[0].doubleValue(),
+                        tBbox.getUpperRight()[1].doubleValue(),
+                        OgcCrs.CRS84))
+            .or(() -> apiData.getDefaultExtent().flatMap(CollectionExtent::getSpatial));
     this.bbox =
-        finalSpatialExtent
+        spatialExtent
             .map(
                 boundingBox ->
                     ImmutableMap.of(
@@ -174,19 +185,19 @@ public class TileSetsView extends OgcApiView {
                       ts.getCenterPoint().isPresent()
                               && ts.getCenterPoint().get().getCoordinates().size() >= 2
                           ? Double.toString(ts.getCenterPoint().get().getCoordinates().get(0))
-                          : finalSpatialExtent.isPresent()
+                          : spatialExtent.isPresent()
                               ? Double.toString(
-                                  finalSpatialExtent.get().getXmax() * 0.5
-                                      + finalSpatialExtent.get().getXmin() * 0.5)
+                                  spatialExtent.get().getXmax() * 0.5
+                                      + spatialExtent.get().getXmin() * 0.5)
                               : "0.0";
                   String lat =
                       ts.getCenterPoint().isPresent()
                               && ts.getCenterPoint().get().getCoordinates().size() >= 2
                           ? Double.toString(ts.getCenterPoint().get().getCoordinates().get(1))
-                          : finalSpatialExtent.isPresent()
+                          : spatialExtent.isPresent()
                               ? Double.toString(
-                                  finalSpatialExtent.get().getYmax() * 0.5
-                                      + finalSpatialExtent.get().getYmin() * 0.5)
+                                  spatialExtent.get().getYmax() * 0.5
+                                      + spatialExtent.get().getYmin() * 0.5)
                               : "0.0";
 
                   return new ImmutableMap.Builder<String, String>()
@@ -279,7 +290,7 @@ public class TileSetsView extends OgcApiView {
 
           this.mapClient =
               getMapClient(
-                  Type.MAP_LIBRE, styleUrl, removeZoomLevelConstraints, htmlConfig, layers);
+                  Type.MAP_LIBRE, styleUrl, removeZoomLevelConstraints, center, htmlConfig, layers);
         } else {
           LOGGER.error(
               "Configuration error: {} as the client for the HTML representation of tile sets requires that a tile set with the tiling scheme {} exists.",
@@ -292,7 +303,7 @@ public class TileSetsView extends OgcApiView {
 
         this.mapClient =
             getMapClient(
-                Type.OPEN_LAYERS, styleUrl, removeZoomLevelConstraints, htmlConfig, layers);
+                Type.OPEN_LAYERS, styleUrl, removeZoomLevelConstraints, center, htmlConfig, layers);
       } else {
         LOGGER.error(
             "Configuration error: {} is not a supported map client for the HTML representation of tile sets.",
@@ -308,6 +319,7 @@ public class TileSetsView extends OgcApiView {
       Type type,
       String styleUrl,
       boolean removeZoomLevelConstraints,
+      Optional<TilePoint> center,
       HtmlConfiguration htmlConfig,
       Multimap<String, List<String>> layers) {
     return new ImmutableMapClient.Builder()
@@ -328,6 +340,8 @@ public class TileSetsView extends OgcApiView {
         .popup(Popup.CLICK_PROPERTIES)
         .styleUrl(Optional.ofNullable(styleUrl))
         .removeZoomLevelConstraints(removeZoomLevelConstraints)
+        .center(center.map(TilePoint::getCoordinates).orElse(ImmutableList.of()))
+        .zoom(center.flatMap(TilePoint::getTileMatrix).map(Double::parseDouble))
         .build();
   }
 

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileSetsView.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileSetsView.java
@@ -111,98 +111,98 @@ public class TileSetsView extends OgcApiView {
                         "maxLat", Double.toString(boundingBox.getYmax())))
             .orElse(null);
     this.tileMatrixSetIds =
-        finalSpatialExtent.isPresent()
-            ? tiles.getTilesets().stream()
-                .map(TileSet::getTileMatrixSetId)
-                .filter(
-                    tileMatrixSetId ->
-                        mapClientType.equals(MapClient.Type.OPEN_LAYERS)
-                            || tileMatrixSetId.equals("WebMercatorQuad"))
-                .collect(Collectors.toList())
-            : ImmutableList.of();
+        tiles.getTilesets().stream()
+            .map(TileSet::getTileMatrixSetId)
+            .filter(
+                tileMatrixSetId ->
+                    mapClientType.equals(MapClient.Type.OPEN_LAYERS)
+                        || tileMatrixSetId.equals("WebMercatorQuad"))
+            .collect(Collectors.toList());
     this.tileCollections =
-        finalSpatialExtent.isPresent()
-            ? tiles.getTilesets().stream()
-                .filter(
-                    tms ->
-                        mapClientType.equals(MapClient.Type.OPEN_LAYERS)
-                            || tms.getTileMatrixSetId().equals("WebMercatorQuad"))
-                .map(
-                    tms -> {
-                      String tmsId = tms.getTileMatrixSetId();
-                      TileMatrixSet tileMatrixSet = tileMatrixSets.get(tmsId);
-                      if (tileMatrixSet == null) return null;
-                      BoundingBox bbox = tileMatrixSet.getBoundingBox();
-                      String extent =
-                          "["
-                              + bbox.getXmin()
-                              + ","
-                              + bbox.getYmin()
-                              + ","
-                              + bbox.getXmax()
-                              + ","
-                              + bbox.getYmax()
-                              + "]";
-                      int maxLevel = tileMatrixSet.getMaxLevel();
-                      List<TileMatrix> tileMatrixList = tileMatrixSet.getTileMatrices(0, maxLevel);
-                      String sizes =
-                          String.format(
-                              "[%s]",
-                              tileMatrixList.stream()
-                                  .map(
-                                      tileMatrix ->
-                                          String.format(
-                                              "[%d, %d]",
-                                              tileMatrix.getMatrixWidth(),
-                                              tileMatrix.getMatrixHeight()))
-                                  .collect(Collectors.joining(", ")));
-                      double diff = bbox.getXmax() - bbox.getXmin();
-                      String resolutions =
-                          String.format(
-                              "[%s]",
-                              tileMatrixList.stream()
-                                  .map(
-                                      tileMatrix ->
-                                          String.valueOf(
-                                              diff
-                                                  / (tileMatrix.getMatrixWidth()
-                                                      * tileMatrixSet.getTileSize())))
-                                  .collect(Collectors.joining(", ")));
+        tiles.getTilesets().stream()
+            .filter(
+                ts ->
+                    mapClientType.equals(MapClient.Type.OPEN_LAYERS)
+                        || ts.getTileMatrixSetId().equals("WebMercatorQuad"))
+            .map(
+                ts -> {
+                  String tmsId = ts.getTileMatrixSetId();
+                  TileMatrixSet tileMatrixSet = tileMatrixSets.get(tmsId);
+                  if (tileMatrixSet == null) return null;
+                  BoundingBox bbox = tileMatrixSet.getBoundingBox();
+                  String extent =
+                      "["
+                          + bbox.getXmin()
+                          + ","
+                          + bbox.getYmin()
+                          + ","
+                          + bbox.getXmax()
+                          + ","
+                          + bbox.getYmax()
+                          + "]";
+                  int maxLevel = tileMatrixSet.getMaxLevel();
+                  List<TileMatrix> tileMatrixList = tileMatrixSet.getTileMatrices(0, maxLevel);
+                  String sizes =
+                      String.format(
+                          "[%s]",
+                          tileMatrixList.stream()
+                              .map(
+                                  tileMatrix ->
+                                      String.format(
+                                          "[%d, %d]",
+                                          tileMatrix.getMatrixWidth(),
+                                          tileMatrix.getMatrixHeight()))
+                              .collect(Collectors.joining(", ")));
+                  double diff = bbox.getXmax() - bbox.getXmin();
+                  String resolutions =
+                      String.format(
+                          "[%s]",
+                          tileMatrixList.stream()
+                              .map(
+                                  tileMatrix ->
+                                      String.valueOf(
+                                          diff
+                                              / (tileMatrix.getMatrixWidth()
+                                                  * tileMatrixSet.getTileSize())))
+                              .collect(Collectors.joining(", ")));
 
-                      String level =
-                          tms.getCenterPoint()
-                              .flatMap(TilePoint::getTileMatrix)
-                              .orElse(getDefaultLevel(diff, tileMatrixSet.getMaxLevel()));
-                      String lon =
-                          tms.getCenterPoint().isPresent()
-                                  && tms.getCenterPoint().get().getCoordinates().size() >= 2
-                              ? Double.toString(tms.getCenterPoint().get().getCoordinates().get(0))
-                              : Double.toString(
+                  String level =
+                      ts.getCenterPoint()
+                          .flatMap(TilePoint::getTileMatrix)
+                          .orElse(getDefaultLevel(diff, tileMatrixSet.getMaxLevel()));
+                  String lon =
+                      ts.getCenterPoint().isPresent()
+                              && ts.getCenterPoint().get().getCoordinates().size() >= 2
+                          ? Double.toString(ts.getCenterPoint().get().getCoordinates().get(0))
+                          : finalSpatialExtent.isPresent()
+                              ? Double.toString(
                                   finalSpatialExtent.get().getXmax() * 0.5
-                                      + finalSpatialExtent.get().getXmin() * 0.5);
-                      String lat =
-                          tms.getCenterPoint().isPresent()
-                                  && tms.getCenterPoint().get().getCoordinates().size() >= 2
-                              ? Double.toString(tms.getCenterPoint().get().getCoordinates().get(1))
-                              : Double.toString(
+                                      + finalSpatialExtent.get().getXmin() * 0.5)
+                              : "0.0";
+                  String lat =
+                      ts.getCenterPoint().isPresent()
+                              && ts.getCenterPoint().get().getCoordinates().size() >= 2
+                          ? Double.toString(ts.getCenterPoint().get().getCoordinates().get(1))
+                          : finalSpatialExtent.isPresent()
+                              ? Double.toString(
                                   finalSpatialExtent.get().getYmax() * 0.5
-                                      + finalSpatialExtent.get().getYmin() * 0.5);
+                                      + finalSpatialExtent.get().getYmin() * 0.5)
+                              : "0.0";
 
-                      return new ImmutableMap.Builder<String, String>()
-                          .put("tileMatrixSet", tmsId)
-                          .put("maxLevel", String.valueOf(maxLevel))
-                          .put("extent", extent)
-                          .put("defaultZoomLevel", level)
-                          .put("defaultCenterLon", lon)
-                          .put("defaultCenterLat", lat)
-                          .put("resolutions", resolutions)
-                          .put("sizes", sizes)
-                          .put("projection", "EPSG:" + tileMatrixSet.getCrs().getCode())
-                          .build()
-                          .entrySet();
-                    })
-                .collect(Collectors.toList())
-            : ImmutableList.of();
+                  return new ImmutableMap.Builder<String, String>()
+                      .put("tileMatrixSet", tmsId)
+                      .put("maxLevel", String.valueOf(maxLevel))
+                      .put("extent", extent)
+                      .put("defaultZoomLevel", level)
+                      .put("defaultCenterLon", lon)
+                      .put("defaultCenterLat", lat)
+                      .put("resolutions", resolutions)
+                      .put("sizes", sizes)
+                      .put("projection", "EPSG:" + tileMatrixSet.getCrs().getCode())
+                      .build()
+                      .entrySet();
+                })
+            .collect(Collectors.toList());
 
     List<Link> tileTemplates =
         tiles.getTilesets().stream()

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureCollectionView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureCollectionView.java
@@ -130,6 +130,7 @@ public class FeatureCollectionView extends DatasetView {
               .popup(Popup.HOVER_ID)
               .styleUrl(Optional.ofNullable(styleUrl))
               .removeZoomLevelConstraints(removeZoomLevelConstraints)
+              .useBounds(true)
               .build();
     } else if (mapClientType.equals(MapClient.Type.CESIUM)) {
       this.mapClient =

--- a/ogcapi-stable/ogcapi-html/src/main/java/de/ii/ogcapi/html/domain/MapClient.java
+++ b/ogcapi-stable/ogcapi-html/src/main/java/de/ii/ogcapi/html/domain/MapClient.java
@@ -49,7 +49,16 @@ public interface MapClient {
     return false;
   }
 
+  List<Double> getCenter();
+
+  Optional<Number> getZoom();
+
   Optional<Map<String, String>> getBounds();
+
+  @Value.Default
+  default boolean getUseBounds() {
+    return false;
+  }
 
   @Value.Default
   default boolean drawBounds() {

--- a/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/mapClient.mustache
+++ b/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/mapClient.mustache
@@ -11,6 +11,12 @@
       {{#removeZoomLevelConstraints}}
         removeZoomLevelConstraints: {{.}},
       {{/removeZoomLevelConstraints}}
+      {{#useBounds}}
+        {{#bounds}}
+          bounds: [[{{minLng}},{{minLat}}],[{{maxLng}},{{maxLat}}]],
+          drawBounds: {{drawBounds}},
+        {{/bounds}}
+      {{/useBounds}}
     {{/styleUrl}}
     {{^styleUrl}}
       {{#backgroundUrl}}
@@ -19,13 +25,17 @@
       {{#attribution}}
         attribution: '{{{.}}}',
       {{/attribution}}
-      //center: [{{centerLon}},{{centerLat}}],
-      //zoom: {{zoom}},
+      {{#zoom}}
+        zoom: {{.}},
+        center: {{center}},
+      {{/zoom}}
+      {{^zoom}}
+        {{#bounds}}
+          bounds: [[{{minLng}},{{minLat}}],[{{maxLng}},{{maxLat}}]],
+          drawBounds: {{drawBounds}},
+        {{/bounds}}
+      {{/zoom}}
     {{/styleUrl}}
-    {{#bounds}}
-      bounds: [[{{minLng}},{{minLat}}],[{{maxLng}},{{maxLat}}]],
-      drawBounds: {{drawBounds}},
-    {{/bounds}}
     {{#data}}
      {{#isData}}
       dataUrl:  {{{url}}},


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #779 

Tested with demo configurations plus in addition also a zoomstack API that provides no features, just tiles using the MBTiles file.

#### HTML

In cases where the API or collection has no associated spatial extent (e.g., an API with a MBTiles provider), the information for each tile matrix set was not passed to the HTML representation.

The initial view of a map is determined as follows: For feature views, always use the bounding box of the features. For tile views, the following sequence is used:

1. Use the style, if available, which will use the center/zoom specified in the style
2. Use center/zoom, if available (from the tileset, either from the configuration or from the MBTiles metadata)
3. Use bounding box, if available (from the tileset, either from the feature data or from the MBTiles metadata)
4. Use default spatial extent (only for tile views, from the API configuration)

#### TileSet resources

For MBTiles providers:

- include vector layers
- use bounding box from metadata

This still needs to be updated for the new tile providers.

