### PR TITLE
Features HTML: improve hideMap behavior

### DIFF
--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureCollectionView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureCollectionView.java
@@ -52,7 +52,7 @@ public class FeatureCollectionView extends DatasetView {
   public List<NavigationDTO> pagination;
   public List<NavigationDTO> metaPagination;
   public List<FeatureHtml> features;
-  public boolean hideMap = true; // set to "hide"; change to "false" when we see a geometry
+  public boolean hideMap;
   public Set<Map.Entry<String, String>> filterFields;
   public Map<String, String> bbox;
   public TemporalExtent temporalExtent;
@@ -88,6 +88,7 @@ public class FeatureCollectionView extends DatasetView {
       Type mapClientType,
       String styleUrl,
       boolean removeZoomLevelConstraints,
+      boolean hideMap,
       Map<String, String> queryables,
       List<String> geometryProperties) {
     super(template, uri, name, title, description, attribution, urlPrefix, htmlConfig, noIndex);
@@ -102,6 +103,7 @@ public class FeatureCollectionView extends DatasetView {
     this.mapPosition = mapPosition;
     this.uriBuilder = new URICustomizer(uri);
     this.cesiumData = new CesiumData(features, geometryProperties);
+    this.hideMap = hideMap;
 
     this.bbox =
         spatialExtent

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureEncoderHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeatureEncoderHtml.java
@@ -186,10 +186,6 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
 
   @Override
   public void onFeature(FeatureHtml feature) {
-    if (transformationContext.collectionView().hideMap && feature.hasGeometry()) {
-      transformationContext.collectionView().hideMap = false;
-    }
-
     transformationContext
         .featuresHtmlConfiguration()
         .getFeatureTitleTemplate()

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
@@ -262,6 +262,14 @@ public class FeaturesFormatHtml
                     nameValuePair.getName().equals("bare")
                         && nameValuePair.getValue().equals("true"));
 
+    boolean hideMap =
+        transformationContext
+            .getFeatureSchema()
+            .flatMap(
+                x ->
+                    x.getProperties().stream().filter(FeatureSchema::isPrimaryGeometry).findFirst())
+            .isEmpty();
+
     if (transformationContext.isFeatureCollection()) {
       FeatureTypeConfigurationOgcApi collectionData = apiData.getCollections().get(collectionName);
 
@@ -310,6 +318,7 @@ public class FeaturesFormatHtml
               language,
               isNoIndexEnabledForApi(apiData),
               getMapPosition(apiData, collectionName),
+              hideMap,
               getGeometryProperties(apiData, collectionName));
 
       addDatasetNavigation(
@@ -334,6 +343,7 @@ public class FeaturesFormatHtml
               isNoIndexEnabledForApi(apiData),
               apiData.getSubPath(),
               getMapPosition(apiData, collectionName),
+              hideMap,
               getGeometryProperties(apiData, collectionName));
     }
 
@@ -362,6 +372,7 @@ public class FeaturesFormatHtml
       Optional<Locale> language,
       boolean noIndex,
       POSITION mapPosition,
+      boolean hideMap,
       List<String> geometryProperties) {
     OgcApiDataV2 apiData = api.getData();
     URI requestUri = null;
@@ -415,6 +426,7 @@ public class FeaturesFormatHtml
             mapClientType,
             styleUrl,
             removeZoomLevelConstraints,
+            hideMap,
             filterableFields,
             geometryProperties);
 
@@ -453,6 +465,7 @@ public class FeaturesFormatHtml
       boolean noIndex,
       List<String> subPathToLandingPage,
       FeaturesHtmlConfiguration.POSITION mapPosition,
+      boolean hideMap,
       List<String> geometryProperties) {
     OgcApiDataV2 apiData = api.getData();
     String rootTitle = i18n.get("root", language);
@@ -518,6 +531,7 @@ public class FeaturesFormatHtml
             mapClientType,
             styleUrl,
             removeZoomLevelConstraints,
+            hideMap,
             null,
             geometryProperties);
     featureTypeDataset.description = featureType.getDescription().orElse(featureType.getLabel());


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Previously transformations on geometry properties had no effect. This was fixed in #719. In the Features HTML representation, no map is shown when no geometry is present in the data. Since the bugfix, no map is now shown, if the Features HTML configuration included a transformation that removes the geometry property from the response. Such a transformation does not really make sense, but is present in some existing API configurations. To support those configurations, the behavior is changed to hide the map, if the feature schema (without transformations) includes a primary geometry property.