### PR TITLE
fix conformance class URIs

### DIFF
--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/EndpointCrud.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/EndpointCrud.java
@@ -134,12 +134,10 @@ public class EndpointCrud extends EndpointSubCollection implements ConformanceCl
   @Override
   public List<String> getConformanceClassUris(OgcApiDataV2 apiData) {
     return ImmutableList.of(
-        "http://www.opengis.net/spec/ogcapi-features-4/1.0/req/create-replace-delete",
-        "http://www.opengis.net/spec/ogcapi-features-4/1.0/req/optimistic-locking",
-        "http://www.opengis.net/spec/ogcapi-features-4/1.0/req/features"
-        // TODO
-        // "http://www.opengis.net/spec/ogcapi-features-4/1.0/req/create-replace-delete/update"
-        );
+        "http://www.opengis.net/spec/ogcapi-features-4/0.0/conf/create-replace-delete",
+        "http://www.opengis.net/spec/ogcapi-features-4/0.0/conf/update",
+        "http://www.opengis.net/spec/ogcapi-features-4/0.0/conf/optimistic-locking",
+        "http://www.opengis.net/spec/ogcapi-features-4/0.0/conf/features");
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
@@ -224,7 +224,7 @@ public class QueryParameterFilter extends ApiExtensionCache
     if (isItemTypeUsed(apiData, FeaturesCoreConfiguration.ItemType.record))
       builder.add(
           "http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/features-filter",
-          "http://www.opengis.net/spec/ogcapi-records-1/0.0/req/cql-filter");
+          "http://www.opengis.net/spec/ogcapi-records-1/0.0/conf/cql-filter");
 
     return builder.build();
   }

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatJPEG.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatJPEG.java
@@ -71,7 +71,7 @@ public class TileFormatJPEG extends TileFormatExtension implements ConformanceCl
     if (isEnabledForApi(apiData)
         || apiData.getCollections().keySet().stream()
             .anyMatch(collectionId -> isEnabledForApi(apiData, collectionId))) {
-      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/jpeg");
+      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg");
     }
 
     return ImmutableList.of();

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatMVT.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatMVT.java
@@ -146,7 +146,7 @@ public class TileFormatMVT extends TileFormatWithQuerySupportExtension implement
     if (isEnabledForApi(apiData)
         || apiData.getCollections().keySet().stream()
             .anyMatch(collectionId -> isEnabledForApi(apiData, collectionId))) {
-      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/mvt");
+      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt");
     }
 
     return ImmutableList.of();

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatPNG.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatPNG.java
@@ -71,7 +71,7 @@ public class TileFormatPNG extends TileFormatExtension implements ConformanceCla
     if (isEnabledForApi(apiData)
         || apiData.getCollections().keySet().stream()
             .anyMatch(collectionId -> isEnabledForApi(apiData, collectionId))) {
-      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/png");
+      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/png");
     }
 
     return ImmutableList.of();

--- a/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatTIFF.java
+++ b/ogcapi-draft/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TileFormatTIFF.java
@@ -71,7 +71,7 @@ public class TileFormatTIFF extends TileFormatExtension implements ConformanceCl
     if (isEnabledForApi(apiData)
         || apiData.getCollections().keySet().stream()
             .anyMatch(collectionId -> isEnabledForApi(apiData, collectionId))) {
-      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/tiff");
+      return ImmutableList.of("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tiff");
     }
 
     return ImmutableList.of();

--- a/ogcapi-stable/ogcapi-oas30/src/main/java/de/ii/ogcapi/oas30/app/EndpointOpenApi.java
+++ b/ogcapi-stable/ogcapi-oas30/src/main/java/de/ii/ogcapi/oas30/app/EndpointOpenApi.java
@@ -33,7 +33,7 @@ public class EndpointOpenApi implements ConformanceClass {
     // TODO only return the URIs for Features and Tiles, if the building blocks are enabled
     return ImmutableList.of(
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/req/oas30",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30");
   }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Several conformance class URIs included "req" in the path instead of "conf". Some of them were introduced in #802. In CRUD the "update" conformance class was not enabled.