### PR TITLE
Reduce limit value for route queries

### DIFF
--- a/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/infra/EndpointRoutesPost.java
+++ b/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/infra/EndpointRoutesPost.java
@@ -96,6 +96,8 @@ public class EndpointRoutesPost extends Endpoint implements ConformanceClass {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EndpointRoutesPost.class);
   private static final List<String> TAGS = ImmutableList.of("Routing");
+  // TODO determine the appropriate segment limit
+  public static final int LIMIT = 250_000;
 
   private final QueryHandlerRoutes queryHandler;
   private final Schema<?> schemaRouteDefinition;
@@ -364,8 +366,8 @@ public class EndpointRoutesPost extends Endpoint implements ConformanceClass {
             defaultCrs,
             coordinatePrecision,
             1,
-            Integer.MAX_VALUE,
-            Integer.MAX_VALUE,
+            LIMIT,
+            LIMIT,
             toFlatMap(uriInfo.getQueryParameters()),
             allowedParameters);
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

For a routing query, the limit / page size is currently 2147483647 features/segments. Due to the optimization to fetch the query response in chunks, this results in a potentially large number of chunks. Since the route is currently constructed in memory, there are practical limits to the size of a route. The limit has been reduced to 250,000 segments for now, but a TODO has been added to review the limit.
