### PR TITLE
Add support for CESIUM_primitive_outline

### DIFF
--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
@@ -1005,7 +1005,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
 
       Integer accessorIdOutline = null;
       if (context.getGltfConfiguration().writeOutline()) {
-        // write normals and add accessor
+        // write outline edges and add accessor
         if (indices.size() <= Short.MAX_VALUE - Short.MIN_VALUE) {
           componentType = UNSIGNED_SHORT;
         } else {

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
@@ -68,6 +68,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
   private static final String INDICES = "_indices";
   private static final String VERTICES = "_vertices";
   private static final String NORMALS = "_normals";
+  private static final String OUTLINE = "_outline";
   private static final String PROPERTY_PREFIX = "_p_";
   private static final int BUFFER_VIEW_NORMALS = 2;
   private static final int BUFFER_VIEW_INDICES = 0;
@@ -106,6 +107,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
   private static final int UNSIGNED_INT = 5125;
   private static final int FLOAT = 5126;
   private static final int TRIANGLES = 4;
+  public static final String CESIUM_PRIMITIVE_OUTLINE = "CESIUM_primitive_outline";
 
   private final FeatureTransformationContextGltf transformationContext;
   private final OutputStream outputStream;
@@ -351,6 +353,10 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     }
     buffers.put(FEATURE_ID, new ByteArrayOutputStream(getByteStrideFeatureId() * INITIAL_SIZE));
     currentBufferViewOffsets.put(FEATURE_ID, 0);
+    if (transformationContext.getGltfConfiguration().writeOutline()) {
+      buffers.put(OUTLINE, new ByteArrayOutputStream(getByteStrideOutline() * INITIAL_SIZE));
+      currentBufferViewOffsets.put(OUTLINE, 0);
+    }
     transformationContext
         .getProperties()
         .forEach(
@@ -481,6 +487,19 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
       nextBufferViewId++;
     }
 
+    if (transformationContext.getGltfConfiguration().writeOutline()) {
+      size = buffers.get(OUTLINE).size();
+      builder.addBufferViews(
+          ImmutableBufferView.builder()
+              .buffer(0)
+              .byteLength(size)
+              .byteOffset(offset)
+              .target(ELEMENT_ARRAY_BUFFER)
+              .build());
+      offset += size;
+      nextBufferViewId++;
+    }
+
     for (Map.Entry<String, ByteArrayOutputStream> entry : buffers.entrySet()) {
       String bufferName = entry.getKey();
       if (bufferName.startsWith(PROPERTY_PREFIX) && !bufferName.endsWith(STRING_OFFSET)) {
@@ -528,6 +547,10 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     if (transformationContext.getGltfConfiguration().useMeshQuantization()) {
       builder.addExtensionsUsed(KHR_MESH_QUANTIZATION);
       builder.addExtensionsRequired(KHR_MESH_QUANTIZATION);
+    }
+
+    if (transformationContext.getGltfConfiguration().writeOutline()) {
+      builder.addExtensionsUsed(CESIUM_PRIMITIVE_OUTLINE);
     }
 
     builder.addMaterials(
@@ -590,6 +613,9 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     if (!transformationContext.getProperties().isEmpty()) {
       bufferList.add(buffers.get(FEATURE_ID));
     }
+    if (transformationContext.getGltfConfiguration().writeOutline()) {
+      bufferList.add(buffers.get(OUTLINE));
+    }
     bufferList.addAll(
         bufferViews.entrySet().stream()
             .sorted(Comparator.comparingInt(Entry::getValue))
@@ -609,6 +635,10 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
 
   private int getByteStrideNormals() {
     return (transformationContext.getGltfConfiguration().useMeshQuantization() ? 1 : 3) * 4;
+  }
+
+  private int getByteStrideOutline() {
+    return getByteStrideIndices();
   }
 
   private int getByteStrideFeatureId() {
@@ -640,6 +670,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     List<Double> normals = new ArrayList<>();
     List<Integer> indices = new ArrayList<>();
     List<Integer> featureIds = new ArrayList<>();
+    List<Integer> outline = new ArrayList<>();
     int indexCount = 0;
     int surfaceCount = 0;
 
@@ -653,6 +684,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
               minMax[0][2],
               context.getClampToEllipsoid(),
               context.getGltfConfiguration().writeNormals(),
+              context.getGltfConfiguration().writeOutline(),
               indexCount,
               Optional.of(context.getCrsTransformerCrs84hToEcef()),
               featureName);
@@ -667,6 +699,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
 
       vertices.addAll(triangleMesh.getVertices());
       normals.addAll(triangleMesh.getNormals());
+      outline.addAll(triangleMesh.getOutlineIndices());
 
       final int nextFeatureId = state.getNextFeatureId() + 1;
       IntStream.range(0, vertexCountSurface).forEach(i -> featureIds.add(nextFeatureId - 1));
@@ -862,6 +895,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
       state.setNextAccessorId(nextAccessorId);
       currentBufferViewOffsets.put(VERTICES, buffers.get(VERTICES).size());
 
+      int nextBufferView = BUFFER_VIEW_NORMALS;
       if (context.getGltfConfiguration().writeNormals()) {
         // write normals and add accessor
         buffer = buffers.get(NORMALS);
@@ -890,7 +924,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
         final List<Double> normalsMax = getMax(normals);
         builder.addAccessors(
             ImmutableAccessor.builder()
-                .bufferView(BUFFER_VIEW_NORMALS)
+                .bufferView(nextBufferView++)
                 .byteOffset(currentBufferViewOffsets.get(NORMALS))
                 .componentType(quantizeMesh ? BYTE : FLOAT)
                 .normalized(quantizeMesh)
@@ -958,7 +992,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
 
         builder.addAccessors(
             ImmutableAccessor.builder()
-                .bufferView(context.getGltfConfiguration().writeNormals() ? 3 : 2)
+                .bufferView(nextBufferView++)
                 .byteOffset(currentBufferViewOffsets.get(FEATURE_ID))
                 .componentType(componentType)
                 .count(featureIds.size())
@@ -969,6 +1003,53 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
         currentBufferViewOffsets.put(FEATURE_ID, buffer.size());
       }
 
+      Integer accessorIdOutline = null;
+      if (context.getGltfConfiguration().writeOutline()) {
+        // write normals and add accessor
+        if (indices.size() <= Short.MAX_VALUE - Short.MIN_VALUE) {
+          componentType = UNSIGNED_SHORT;
+        } else {
+          componentType = UNSIGNED_INT;
+        }
+
+        // write indices and add accessor
+        buffer = buffers.get(OUTLINE);
+        switch (componentType) {
+          case UNSIGNED_SHORT:
+            for (int v : outline) {
+              buffer.write(GltfAsset.intToLittleEndianShort(v));
+            }
+            break;
+
+          case UNSIGNED_INT:
+          default:
+            for (int v : outline) {
+              buffer.write(GltfAsset.intToLittleEndianInt(v));
+            }
+            break;
+        }
+
+        builder.addAccessors(
+            ImmutableAccessor.builder()
+                .bufferView(nextBufferView++)
+                .byteOffset(currentBufferViewOffsets.get(OUTLINE))
+                .componentType(componentType)
+                .addMax(outline.stream().max(Comparator.naturalOrder()).orElseThrow())
+                .addMin(outline.stream().min(Comparator.naturalOrder()).orElseThrow())
+                .count(outline.size())
+                .type("SCALAR")
+                .build());
+
+        // pad for alignment, all offsets must be divisible by 4
+        while (buffers.get(OUTLINE).size() % 4 > 0) {
+          buffers.get(OUTLINE).write(GltfAsset.BIN_PADDING);
+        }
+
+        accessorIdOutline = nextAccessorId++;
+        state.setNextAccessorId(nextAccessorId);
+        currentBufferViewOffsets.put(OUTLINE, buffers.get(OUTLINE).size());
+      }
+
       // add mesh and node for the feature
       ImmutableList.Builder<Map<String, Object>> featureIdsBuilder = ImmutableList.builder();
       if (!context.getProperties().isEmpty()) {
@@ -976,6 +1057,15 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
             ImmutableMap.of("featureCount", surfaceCount, "attribute", 0, "propertyTable", 0));
       }
       List<Map<String, Object>> meshFeatures = featureIdsBuilder.build();
+      ImmutableMap.Builder<String, Map<String, Object>> extensionsBuilder =
+          new ImmutableMap.Builder<>();
+      if (!meshFeatures.isEmpty()) {
+        extensionsBuilder.put(EXT_MESH_FEATURES, ImmutableMap.of("featureIds", meshFeatures));
+      }
+      if (Objects.nonNull(accessorIdOutline)) {
+        extensionsBuilder.put(
+            CESIUM_PRIMITIVE_OUTLINE, ImmutableMap.of("indices", accessorIdOutline));
+      }
       builder.addMeshes(
           ImmutableMesh.builder()
               .addPrimitives(
@@ -984,11 +1074,7 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
                       .mode(TRIANGLES)
                       .indices(accessorIdIndices)
                       .material(MATERIAL)
-                      .extensions(
-                          meshFeatures.isEmpty()
-                              ? ImmutableMap.of()
-                              : ImmutableMap.of(
-                                  EXT_MESH_FEATURES, ImmutableMap.of("featureIds", meshFeatures)))
+                      .extensions(extensionsBuilder.build())
                       .build())
               .build());
 

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/GltfBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/GltfBuildingBlock.java
@@ -97,6 +97,7 @@ public class GltfBuildingBlock implements ApiBuildingBlock {
         .enabled(false)
         .meshQuantization(true)
         .withNormals(true)
+        .withOutline(false)
         .polygonOrientationNotGuaranteed(true)
         .withSurfaceType(false)
         .maxMultiplicity(DEFAULT_MULTIPLICITY)

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/domain/GltfConfiguration.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/domain/GltfConfiguration.java
@@ -7,9 +7,9 @@
  */
 package de.ii.ogcapi.features.gltf.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
-import de.ii.xtraplatform.docs.DocIgnore;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -69,7 +69,7 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   Boolean getMeshQuantization();
 
   @Value.Derived
-  @DocIgnore
+  @JsonIgnore
   default boolean useMeshQuantization() {
     return Boolean.TRUE.equals(getMeshQuantization());
   }
@@ -84,7 +84,7 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   Boolean getWithNormals();
 
   @Value.Derived
-  @DocIgnore
+  @JsonIgnore
   default boolean writeNormals() {
     return Boolean.TRUE.equals(getWithNormals());
   }
@@ -99,7 +99,7 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   Boolean getWithOutline();
 
   @Value.Derived
-  @DocIgnore
+  @JsonIgnore
   default boolean writeOutline() {
     return Boolean.TRUE.equals(getWithOutline());
   }
@@ -117,7 +117,7 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   Boolean getPolygonOrientationNotGuaranteed();
 
   @Value.Derived
-  @DocIgnore
+  @JsonIgnore
   default boolean polygonOrientationIsNotGuaranteed() {
     return Boolean.TRUE.equals(getPolygonOrientationNotGuaranteed());
   }
@@ -167,7 +167,7 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   Boolean getWithSurfaceType();
 
   @Value.Derived
-  @DocIgnore
+  @JsonIgnore
   default boolean includeSurfaceType() {
     return Boolean.TRUE.equals(getWithSurfaceType());
   }

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/domain/GltfConfiguration.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/domain/GltfConfiguration.java
@@ -90,6 +90,21 @@ public interface GltfConfiguration extends ExtensionConfiguration, PropertyTrans
   }
 
   /**
+   * @langEn If `true`, the polygon edges are outlined in Cesium.
+   * @langDe Wenn `true`, werden die Kanten der Polygone in Cesium hervorgehoben.
+   * @default false
+   * @since v3.4
+   */
+  @Nullable
+  Boolean getWithOutline();
+
+  @Value.Derived
+  @DocIgnore
+  default boolean writeOutline() {
+    return Boolean.TRUE.equals(getWithOutline());
+  }
+
+  /**
    * @langEn If `true`, materials are defined as
    *     [double-sided](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#double-sided).
    * @langDe Wenn `true`, werden Materialien als

--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/Cesium/index.jsx
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/Cesium/index.jsx
@@ -11,6 +11,7 @@ import {
   Cesium3DTileStyle,
   Matrix4,
   Cartesian3,
+  Color,
 } from "c137.js";
 
 import "./style.css";
@@ -77,7 +78,7 @@ const Cesium = ({
   }
 
   if (getTileset) {
-    const tileset = getTileset(Cesium3DTileset, Matrix4, Cartesian3);
+    const tileset = getTileset(Cesium3DTileset, Matrix4, Cartesian3, Color);
     if (getStyle) {
       tileset.style = getStyle(Cesium3DTileStyle);
     }

--- a/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/data-cesium.mustache
+++ b/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/data-cesium.mustache
@@ -6,7 +6,7 @@ globalThis._cesium = {
   {{#featureExtent}}
   getExtent: (Rectangle) => {{.}},
   {{/featureExtent}}
-  getTileset: (Cesium3DTileset, Matrix4, Cartesian3) => new Cesium3DTileset({
+  getTileset: (Cesium3DTileset, Matrix4, Cartesian3, Color) => new Cesium3DTileset({
     {{#fromFeatures}}
     url: 'data:application/json,%7B%22asset%22%3A%7B%22version%22%3A%221.1%22%7D%2C%22geometricError%22%3A5000%2C%22root%22%3A%7B%22boundingVolume%22%3A%7B%22region%22%3A%5B{{{encodedRegion}}}%5D%7D%2C%22refine%22%3A%22REPLACE%22%2C%22geometricError%22%3A0%2C%22content%22%3A%7B%22uri%22%3A%22{{{encodedUrl}}}%22%7D%7D%7D',
     {{/fromFeatures}}
@@ -16,6 +16,7 @@ globalThis._cesium = {
     modelMatrix: Matrix4.fromTranslation(Cartesian3.subtract(Cartesian3.fromRadians({{centerLon}}, {{centerLat}}, {{centerHeight}}+({{.}})), Cartesian3.fromRadians({{centerLon}}, {{centerLat}}, {{centerHeight}}), new Cartesian3())),
     {{/terrainHeightDifference}}
     {{/fromTiles}}
+    outlineColor: Color.DARKSLATEGREY,
   }),
   {{#ionAccessToken}}
   accessToken: '{{.}}',

--- a/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/data-cesium.mustache
+++ b/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/data-cesium.mustache
@@ -16,7 +16,7 @@ globalThis._cesium = {
     modelMatrix: Matrix4.fromTranslation(Cartesian3.subtract(Cartesian3.fromRadians({{centerLon}}, {{centerLat}}, {{centerHeight}}+({{.}})), Cartesian3.fromRadians({{centerLon}}, {{centerLat}}, {{centerHeight}}), new Cartesian3())),
     {{/terrainHeightDifference}}
     {{/fromTiles}}
-    outlineColor: Color.DARKSLATEGREY,
+    outlineColor: Color.DIMGREY,
   }),
   {{#ionAccessToken}}
   accessToken: '{{.}}',


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #939

I have tested the outline extension using [Cesium Sandcastle](https://sandcastle.cesium.com/) with a tile set provided by ldproxy.

Without outline (ldproxy Cesium client):
<img width="1364" alt="without-outline" src="https://user-images.githubusercontent.com/4245251/225269292-419e3058-0794-43f5-ab50-1cea00bd21f5.png">

With outline (using Sandcastle):
<img width="1106" alt="with-outline" src="https://user-images.githubusercontent.com/4245251/225288523-02a96970-3427-4c96-8b66-5ea758a97201.png">

Sandcastle code using `gebaeude` (LoD1):

```javascript
const viewer = new Cesium.Viewer("cesiumContainer", {});

const buildingsTileset = new Cesium.Cesium3DTileset({
    url: 'data:application/json,%7B%22asset%22%3A%7B%22version%22%3A%221.1%22%2C%22generator%22%3A%22ldproxy%22%2C%22copyright%22%3A%22Bezirksregierung+K%C3%B6ln%2C+%3Ca+href%3D%5C%22http%3A%2F%2Fwww.geobasis.nrw.de%2F%5C%22+target%3D%5C%22_blank%5C%22%3EGeobasis+NRW%3C%2Fa%3E%22%7D%2C%22geometricError%22%3A10000.0%2C%22root%22%3A%7B%22boundingVolume%22%3A%7B%22region%22%3A%5B0.11112818617709905%2C0.8786910012799107%2C0.12277548885769542%2C0.9106829409540936%2C0.0%2C615.01%5D%7D%2C%22geometricError%22%3A8192.0%2C%22refine%22%3A%22ADD%22%2C%22content%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A7080%2Frest%2Fservices%2Fgebaeude_lod1%2Fcollections%2Fbuilding%2F3dtiles%2Fcontent_%257Blevel%257D_%257Bx%257D_%257By%257D%22%7D%2C%22implicitTiling%22%3A%7B%22subdivisionScheme%22%3A%22QUADTREE%22%2C%22availableLevels%22%3A10%2C%22subtreeLevels%22%3A3%2C%22subtrees%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A7080%2Frest%2Fservices%2Fgebaeude_lod1%2Fcollections%2Fbuilding%2F3dtiles%2Fsubtree_%257Blevel%257D_%257Bx%257D_%257By%257D%22%7D%7D%7D%2C%22schemaUri%22%3A%22http%3A%2F%2Flocalhost%3A7080%2Frest%2Fservices%2Fgebaeude_lod1%2Fcollections%2Fbuilding%2Fgltf%2Fschema%22%2C%22extensionsUsed%22%3A%5B%223DTILES_content_gltf%22%2C%223DTILES_implicit_tiling%22%2C%223DTILES_metadata%22%5D%2C%22extensionsRequired%22%3A%5B%223DTILES_content_gltf%22%2C%223DTILES_implicit_tiling%22%5D%7D',
    outlineColor: Cesium.Color.DIMGREY,
  });
viewer.scene.primitives.add(buildingsTileset);

viewer.scene.camera.setView({
  destination: Cesium.Cartesian3.fromDegrees(6.7637802, 51.2075126, 200),
  orientation: {
    heading: Cesium.Math.toRadians(10),
    pitch: Cesium.Math.toRadians(-10),
  },
});

buildingsTileset.style = new Cesium.Cesium3DTileStyle({});
```
