### PR TITLE
Search: Remove links from responses to ad-hoc queries

### DIFF
--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointAdHocQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointAdHocQuery.java
@@ -272,6 +272,7 @@ public class EndpointAdHocQuery extends EndpointRequiresFeatures implements Conf
                     .getExtension(SearchConfiguration.class)
                     .map(SearchConfiguration::getAllLinksAreLocal)
                     .orElse(false))
+            .isStoredQuery(false)
             .build();
 
     return queryHandler.handle(Query.QUERY, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQuery.java
@@ -236,6 +236,7 @@ public class EndpointStoredQuery extends EndpointRequiresFeatures {
                     .getExtension(SearchConfiguration.class)
                     .map(SearchConfiguration::getAllLinksAreLocal)
                     .orElse(false))
+            .isStoredQuery(true)
             .build();
 
     return queryHandler.handle(Query.QUERY, queryInput, requestContext);

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
@@ -131,11 +131,19 @@ import javax.inject.Singleton;
  *     specification in OGC (e.g., whether the payload should be JSON or URL-encoded query
  *     parameters).
  *     </code>
+ *     <p>Ad-hoc queries have the following limitations:
+ *     <p><code>
+ * - Paging is not supported for ad-hoc queries and sufficiently large values for `limit` should be used. See [issue 906](https://github.com/interactive-instruments/ldproxy/issues/906).
+ *     </code>
  * @limitationsDe Für parametrisierte gespeicherte Abfragen gelten die folgenden Beschränkungen:
  *     <p><code>
  * - Parameter können nur in Filterausdrücken vorkommen.
  * - Das JSON-Schema eines Parameters unterstützt eine Teilmenge der Sprache. Insbesondere werden `patternProperties`, `additionalProperties`, `allOf`, `oneOf`, `prefixItems`, `additionalItems` und `items: false` nicht unterstützt.
  * - POST zur Ausführung einer gespeicherten Abfrage wird nicht unterstützt. Dies wird hinzugefügt, nachdem die Spezifikation in OGC diskutiert wurde (z.B. ob die Nutzlast JSON oder URL-kodierte Abfrageparameter sein sollen).
+ *     </code>
+ *     <p>Ad-hoc-Queries haben die folgenden Beschränkungen:
+ *     <p><code>
+ * - Paging wird für Ad-Hoc-Queries nicht unterstützt. Bis zur Klärung sollten ausreichend große Werte für `limit` verwendet werden. Siehe [Issue 906](https://github.com/interactive-instruments/ldproxy/issues/906).
  *     </code>
  * @ref:cfg {@link de.ii.ogcapi.features.search.domain.SearchConfiguration}
  * @ref:cfgProperties {@link de.ii.ogcapi.features.search.domain.ImmutableSearchConfiguration}

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
@@ -523,15 +523,17 @@ public class SearchQueriesHandlerImpl implements SearchQueriesHandler {
                 .collect(Collectors.toUnmodifiableList());
     EpsgCrs targetCrs = query.getCrs().orElse(queryInput.getDefaultCrs());
     List<Link> links =
-        new StoredQueriesLinkGenerator()
-            .generateFeaturesLinks(
-                requestContext.getUriCustomizer(),
-                query.getOffset(),
-                query.getLimit(),
-                requestContext.getMediaType(),
-                requestContext.getAlternateMediaTypes(),
-                i18n,
-                requestContext.getLanguage());
+        queryInput.isStoredQuery()
+            ? new StoredQueriesLinkGenerator()
+                .generateFeaturesLinks(
+                    requestContext.getUriCustomizer(),
+                    query.getOffset(),
+                    query.getLimit(),
+                    requestContext.getMediaType(),
+                    requestContext.getAlternateMediaTypes(),
+                    i18n,
+                    requestContext.getLanguage())
+            : ImmutableList.of();
     FeatureFormatExtension outputFormat =
         requestContext
             .getApi()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
@@ -56,6 +56,8 @@ public interface SearchQueriesHandler extends QueriesHandler<SearchQueriesHandle
     default boolean getAllLinksAreLocal() {
       return false;
     }
+
+    boolean isStoredQuery();
   }
 
   @Value.Immutable


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

This is a first step to address #906. The self, alternate and paging links are removed for ad-hoc queries.

The limitation that ad-hoc queries do not support paging has been documented as a limitation in the building block for now until this issue has been discussed in OGC. For now, use sufficiently large values for the limit parameter to avoid the need for paging.
