### PR TITLE
Edits from pre-release tests

### DIFF
--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
@@ -40,6 +40,7 @@ import de.ii.xtraplatform.features.domain.FeatureStream.Result;
 import de.ii.xtraplatform.features.domain.FeatureStream.ResultBase;
 import de.ii.xtraplatform.features.domain.FeatureStream.ResultReduced;
 import de.ii.xtraplatform.features.domain.FeatureTokenEncoder;
+import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
 import de.ii.xtraplatform.store.domain.entities.EntityRegistry;
 import de.ii.xtraplatform.store.domain.entities.PersistentEntity;
@@ -164,6 +165,14 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
                         MessageFormat.format(
                             "The requested media type ''{0}'' is not supported for this resource.",
                             requestContext.getMediaType())));
+
+    if (outputFormat.getMediaType().type().equals(MediaType.TEXT_HTML_TYPE)
+        && !api.getData()
+            .getExtension(HtmlConfiguration.class, collectionId)
+            .map(HtmlConfiguration::getSendEtags)
+            .orElse(false)) {
+      query = ImmutableFeatureQuery.builder().from(query).eTag(Optional.empty()).build();
+    }
 
     String persistentUri = null;
     Optional<String> template =

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreConfiguration.java
@@ -18,11 +18,11 @@ import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import de.ii.xtraplatform.crs.domain.ImmutableEpsgCrs;
 import de.ii.xtraplatform.crs.domain.OgcCrs;
+import de.ii.xtraplatform.features.domain.FeatureTypeConfiguration;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -382,15 +382,15 @@ public interface FeaturesCoreConfiguration
 
   static String getCollectionId(OgcApiDataV2 apiData, String featureType) {
     return apiData.getCollections().values().stream()
-        .map(
+        .filter(
             collection ->
                 collection
                     .getExtension(FeaturesCoreConfiguration.class)
-                    .flatMap(FeaturesCoreConfiguration::getFeatureType))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .filter(ft -> Objects.equals(ft, featureType))
+                    .flatMap(FeaturesCoreConfiguration::getFeatureType)
+                    .filter(featureType::equals)
+                    .isPresent())
         .findFirst()
+        .map(FeatureTypeConfiguration::getId)
         .orElse(featureType);
   }
 }

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Maps;
 import de.ii.ogcapi.features.core.domain.SfFlatConfiguration;
 import de.ii.ogcapi.foundation.domain.CachingConfiguration;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
+import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.html.domain.MapClient;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformation;
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
@@ -893,5 +895,28 @@ public interface TilesConfiguration extends SfFlatConfiguration, CachingConfigur
         .from(this)
         .transformations(transformations)
         .build();
+  }
+
+  static Optional<FeatureTypeConfigurationOgcApi> getCollectionData(
+      OgcApiDataV2 apiData, String tileset) {
+    Optional<FeatureTypeConfigurationOgcApi> collectionData =
+        apiData.getCollections().values().stream()
+            .filter(
+                collection ->
+                    collection
+                        .getExtension(TilesConfiguration.class)
+                        .map(TilesConfiguration::getTileProviderTileset)
+                        .filter(tileset::equals)
+                        .isPresent())
+            .findFirst();
+
+    if (collectionData.isEmpty()) {
+      collectionData =
+          apiData.getCollections().values().stream()
+              .filter(collection -> collection.getId().equals(tileset))
+              .findFirst();
+    }
+
+    return collectionData;
   }
 }

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.2.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.2.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.2.0-cp-tests1-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.2.0-SNAPSHOT'
 }
 

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.2.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.2.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.2.0-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.2.0-cp-tests1-SNAPSHOT'
 }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

- Fix regression: Title and description were not set for the tilesets in the tilesets metadata. In addition: removed unused vars and simplified code.
- improve featureType->collectionId mapping
- no ETag for HTML unless explicitly configured: This issue was probably already present in 3.3 as a result of the CRUD changes.
- Tiles: add default for center. Regression tests showed that previously there was a center value if a default level was specified, but no center - although I could not really find easily how/where that was computed. Nevertheless it seems reasonable to use the center of the extent as a fallback.
- IS NULL not supported by WFS provider. IS NULL is required to properly implement the `bbox` and `datetime` query parameters, which match all features where the primary geometry or instant is `null`. This has been corrected as part of the recent refactoring of the FeaturesQueryImpl class. For WFS we simply continue to ignore the condition, i.e. drop the IS NULL predicate.
- See also https://github.com/interactive-instruments/xtraplatform-spatial/pull/202.