### PR TITLE
Fix error with SF Flat encodings

### DIFF
--- a/ogcapi-custom/ogcapi-features-csv/src/main/java/de/ii/ogcapi/features/csv/app/FeaturesFormatCsv.java
+++ b/ogcapi-custom/ogcapi-features-csv/src/main/java/de/ii/ogcapi/features/csv/app/FeaturesFormatCsv.java
@@ -135,6 +135,7 @@ public class FeaturesFormatCsv implements ConformanceClass, FeatureFormatExtensi
         new FeatureEncoderCsv(
             ImmutableEncodingContextCsv.builder()
                 .from(transformationContext)
+                .collectionId(collectionId)
                 .schema(schema)
                 .build()));
   }

--- a/ogcapi-custom/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeaturesFormatFlatgeobuf.java
+++ b/ogcapi-custom/ogcapi-features-flatgeobuf/src/main/java/de/ii/ogcapi/features/flatgeobuf/app/FeaturesFormatFlatgeobuf.java
@@ -147,6 +147,7 @@ public class FeaturesFormatFlatgeobuf implements ConformanceClass, FeatureFormat
         new FeatureEncoderFlatgeobuf(
             ImmutableEncodingContextFlatgeobuf.builder()
                 .from(transformationContext)
+                .collectionId(collectionId)
                 .schema(schema)
                 .crsTransformer(transformationContext.getCrsTransformer())
                 .is3d(crsInfo.is3d(crs))


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

The problem was introduced in the Tiles redesign when `collectionId` was removed from `EncodingContextSfFlat` (in xtraplatform-spatial, which is unaware of the OGC API collection concept) and added to CSV and FGB modules - but without setting the value. It was set in the `transformationContext`, but 'invisible' since that was cast to `EncodingContextSfFlat`.
