### PR TITLE
Query parameters for queryables and stored queries only on GET requests

### DIFF
--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParametersStoredQueries.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParametersStoredQueries.java
@@ -64,7 +64,9 @@ public class QueryParametersStoredQueries implements RuntimeQueryParametersExten
       Optional<String> collectionId,
       String definitionPath,
       HttpMethods method) {
-    if (collectionId.isPresent() || !"/search/{queryId}".equals(definitionPath)) {
+    if (collectionId.isPresent()
+        || !"/search/{queryId}".equals(definitionPath)
+        || method != HttpMethods.GET) {
       return ImmutableList.of();
     }
 

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParametersQueryables.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParametersQueryables.java
@@ -90,7 +90,9 @@ public class QueryParametersQueryables
       Optional<String> collectionId,
       String definitionPath,
       HttpMethods method) {
-    if (collectionId.isEmpty() || !"/collections/{collectionId}/items".equals(definitionPath)) {
+    if (collectionId.isEmpty()
+        || !"/collections/{collectionId}/items".equals(definitionPath)
+        || method != HttpMethods.GET) {
       return ImmutableList.of();
     }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

The query parameters for queryables and stored queries were considered applicable on all HTTP methods, not just GET. For example, the queryables query parameters were also available on the POST method to create a feature in the CRUD module.
