### PR TITLE
Support default values for typed query parameters

### DIFF
--- a/ogcapi-custom/ogcapi-features-custom-extensions/src/main/java/de/ii/ogcapi/features/custom/extensions/app/QueryParameterIntersects.java
+++ b/ogcapi-custom/ogcapi-features-custom-extensions/src/main/java/de/ii/ogcapi/features/custom/extensions/app/QueryParameterIntersects.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -103,6 +104,11 @@ public class QueryParameterIntersects extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     FeatureTypeConfigurationOgcApi collectionData =
         optionalCollectionData.orElseThrow(
             () ->

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/QueryParameterClampToEllipsoid.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/QueryParameterClampToEllipsoid.java
@@ -21,6 +21,7 @@ import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -76,7 +77,7 @@ public class QueryParameterClampToEllipsoid extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return Boolean.parseBoolean(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override
@@ -86,7 +87,7 @@ public class QueryParameterClampToEllipsoid extends ApiExtensionCache
 
   @Override
   public Schema<?> getSchema(OgcApiDataV2 apiData) {
-    return new BooleanSchema();
+    return new BooleanSchema()._default(false);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterDryRunStoredQueriesManager.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterDryRunStoredQueriesManager.java
@@ -21,6 +21,7 @@ import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -63,7 +64,7 @@ public class QueryParameterDryRunStoredQueriesManager extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return Boolean.parseBoolean(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -68,7 +69,7 @@ public class QueryParameterOffsetStoredQuery extends ApiExtensionCache
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
     try {
-      return Integer.parseInt(value);
+      return Objects.nonNull(value) ? Integer.parseInt(value) : 0;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format(

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
@@ -547,12 +547,14 @@ public class SearchQueriesHandlerImpl implements SearchQueriesHandler {
                             "The requested media type ''{0}'' is not supported for this resource.",
                             requestContext.getMediaType())));
 
-    // negotiate profile, if the format does not support the selected profile
-    Profile requestedProfile = queryExpression.getProfile().orElse(Profile.AS_LINK);
-    Profile profile =
-        outputFormat.supportsProfile(requestedProfile)
-            ? requestedProfile
-            : outputFormat.negotiateProfile(requestedProfile);
+    // negotiate profile, if profiles are applicable and the format does not support the selected
+    // profile
+    Optional<Profile> profile =
+        queryInput.getProfileIsApplicable()
+            ? Optional.of(
+                outputFormat.negotiateProfile(
+                    queryExpression.getProfile().orElse(Profile.getDefault())))
+            : Optional.empty();
 
     StreamingOutput streamingOutput =
         getStreamingOutput(
@@ -740,7 +742,7 @@ public class SearchQueriesHandlerImpl implements SearchQueriesHandler {
       List<String> collectionIds,
       FeatureProvider2 featureProvider,
       FeatureFormatExtension outputFormat,
-      Profile profile,
+      Optional<Profile> profile,
       boolean showsFeatureSelfLink,
       EpsgCrs defaultCrs,
       EpsgCrs targetCrs,
@@ -833,7 +835,7 @@ public class SearchQueriesHandlerImpl implements SearchQueriesHandler {
       List<String> collectionIds,
       FeatureProvider2 featureProvider,
       FeatureFormatExtension outputFormat,
-      Profile profile,
+      Optional<Profile> profile,
       String serviceUrl) {
     return IntStream.range(0, collectionIds.size())
         .boxed()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
@@ -57,6 +57,8 @@ public interface SearchQueriesHandler extends QueriesHandler<SearchQueriesHandle
       return false;
     }
 
+    boolean getProfileIsApplicable();
+
     boolean isStoredQuery();
   }
 

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
@@ -270,6 +270,11 @@ public class QueryParameterFilter extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     FeatureTypeConfigurationOgcApi collectionData =
         optionalCollectionData.orElseThrow(
             () ->

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterCrs.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterCrs.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -109,7 +110,7 @@ public class QueryParameterFilterCrs extends ApiExtensionCache
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
     EpsgCrs filterCrs;
     try {
-      filterCrs = EpsgCrs.fromString(value);
+      filterCrs = Objects.nonNull(value) ? EpsgCrs.fromString(value) : OgcCrs.CRS84;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format("The parameter '%s' is invalid: %s", getName(), e.getMessage()), e);

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterLang.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterLang.java
@@ -110,10 +110,6 @@ public class QueryParameterFilterLang extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
-    if (value == null) {
-      // no default value
-      return null;
-    }
     return Objects.equals(value, FILTER_LANG_CQL2_JSON) ? Cql.Format.JSON : Cql.Format.TEXT;
   }
 

--- a/ogcapi-draft/ogcapi-geometry-simplification/src/main/java/de/ii/ogcapi/geometry/simplification/app/QueryParameterMaxAllowableOffsetFeatures.java
+++ b/ogcapi-draft/ogcapi-geometry-simplification/src/main/java/de/ii/ogcapi/geometry/simplification/app/QueryParameterMaxAllowableOffsetFeatures.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -67,6 +68,11 @@ public class QueryParameterMaxAllowableOffsetFeatures extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     try {
       return Double.parseDouble(value);
     } catch (NumberFormatException e) {

--- a/ogcapi-draft/ogcapi-projections/src/main/java/de/ii/ogcapi/projections/app/QueryParameterProperties.java
+++ b/ogcapi-draft/ogcapi-projections/src/main/java/de/ii/ogcapi/projections/app/QueryParameterProperties.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -139,6 +140,11 @@ public class QueryParameterProperties extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     try {
       return Splitter.on(',').omitEmptyStrings().trimResults().splitToList(value);
     } catch (Throwable e) {

--- a/ogcapi-draft/ogcapi-projections/src/main/java/de/ii/ogcapi/projections/app/QueryParameterSkipGeometry.java
+++ b/ogcapi-draft/ogcapi-projections/src/main/java/de/ii/ogcapi/projections/app/QueryParameterSkipGeometry.java
@@ -23,6 +23,7 @@ import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery.Builder;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -62,7 +63,7 @@ public class QueryParameterSkipGeometry extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return "true".equalsIgnoreCase(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/app/QueryParameterCrsRoutes.java
+++ b/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/app/QueryParameterCrsRoutes.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -78,7 +79,7 @@ public class QueryParameterCrsRoutes extends ApiExtensionCache
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
     EpsgCrs targetCrs;
     try {
-      targetCrs = EpsgCrs.fromString(value);
+      targetCrs = Objects.nonNull(value) ? EpsgCrs.fromString(value) : OgcCrs.CRS84;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format("The parameter '%s' is invalid: %s", getName(), e.getMessage()), e);

--- a/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeatures.java
+++ b/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeatures.java
@@ -103,6 +103,11 @@ public class QueryParameterSortbyFeatures extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     // the validation against the schema has verified that only valid properties are listed
     ImmutableList.Builder<SortKey> builder = new ImmutableList.Builder<>();
     for (String key : KEYS_SPLITTER.split(value)) {

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/app/manager/QueryParameterDryRunStylesManager.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/app/manager/QueryParameterDryRunStylesManager.java
@@ -66,7 +66,7 @@ public class QueryParameterDryRunStylesManager extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return Boolean.parseBoolean(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-text-search/src/main/java/de/ii/ogcapi/text/search/app/QueryParameterQ.java
+++ b/ogcapi-draft/ogcapi-text-search/src/main/java/de/ii/ogcapi/text/search/app/QueryParameterQ.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -84,6 +85,11 @@ public class QueryParameterQ extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     Set<String> qProperties = new HashSet<>();
     List<String> textSearchProperties =
         optionalCollectionData

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParameterTemplateQueryable.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParameterTemplateQueryable.java
@@ -128,6 +128,11 @@ public abstract class QueryParameterTemplateQueryable extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     switch (getType()) {
       case INTEGER:
       case FLOAT:

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterF.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterF.java
@@ -72,6 +72,11 @@ public abstract class QueryParameterF extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     return extensionRegistry.getExtensionsForType(getFormatClass()).stream()
         .filter(f -> f.isEnabledForApi(api.getData()))
         .map(FormatExtension::getMediaType)

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterLang.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterLang.java
@@ -63,6 +63,11 @@ public class QueryParameterLang extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     return I18n.getLanguages().stream()
         .filter(lang -> Objects.equals(lang.getLanguage(), value))
         .findFirst()

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterBboxCrsFeatures.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterBboxCrsFeatures.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -86,7 +87,7 @@ public class QueryParameterBboxCrsFeatures extends ApiExtensionCache
 
     EpsgCrs bboxCrs;
     try {
-      bboxCrs = EpsgCrs.fromString(value);
+      bboxCrs = Objects.nonNull(value) ? EpsgCrs.fromString(value) : OgcCrs.CRS84;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format("The parameter '%s' is invalid: %s", BBOX_CRS, e.getMessage()), e);

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterCrsFeatures.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterCrsFeatures.java
@@ -25,11 +25,13 @@ import de.ii.ogcapi.foundation.domain.QueryParameterSet;
 import de.ii.ogcapi.foundation.domain.SchemaValidator;
 import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import de.ii.xtraplatform.crs.domain.OgcCrs;
 import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery.Builder;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -83,7 +85,7 @@ public class QueryParameterCrsFeatures extends ApiExtensionCache
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
     EpsgCrs targetCrs;
     try {
-      targetCrs = EpsgCrs.fromString(value);
+      targetCrs = Objects.nonNull(value) ? EpsgCrs.fromString(value) : OgcCrs.CRS84;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format("The parameter '%s' is invalid: %s", getName(), e.getMessage()), e);

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/EndpointFeature.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/EndpointFeature.java
@@ -13,6 +13,7 @@ import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreQueriesHandler;
 import de.ii.ogcapi.features.core.domain.FeaturesQuery;
 import de.ii.ogcapi.features.core.domain.ImmutableQueryInputFeature.Builder;
+import de.ii.ogcapi.features.core.domain.Profile;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
 import de.ii.ogcapi.foundation.domain.ApiRequestContext;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
@@ -126,6 +127,10 @@ public class EndpointFeature extends EndpointFeaturesDefinition {
     QueryParameterSet queryParameterSet =
         QueryParameterSet.of(parameterDefinitions, toFlatMap(uriInfo.getQueryParameters()))
             .evaluate(api, Optional.of(collectionData));
+    Optional<Profile> profile =
+        Optional.ofNullable(
+            (Profile)
+                queryParameterSet.getTypedValues().get(QueryParameterProfileFeatures.PROFILE));
 
     FeatureQuery query =
         ogcApiFeaturesQuery.requestToFeatureQuery(
@@ -143,7 +148,7 @@ public class EndpointFeature extends EndpointFeaturesDefinition {
             .collectionId(collectionId)
             .featureId(featureId)
             .query(query)
-            .profile(QueryParameterProfileFeatures.evaluate(queryParameterSet))
+            .profile(profile)
             .featureProvider(providers.getFeatureProviderOrThrow(api.getData(), collectionData))
             .defaultCrs(coreConfiguration.getDefaultEpsgCrs());
 

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/EndpointFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/EndpointFeatures.java
@@ -16,6 +16,7 @@ import de.ii.ogcapi.features.core.domain.FeaturesCoreQueriesHandler;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreValidation;
 import de.ii.ogcapi.features.core.domain.FeaturesQuery;
 import de.ii.ogcapi.features.core.domain.ImmutableQueryInputFeatures.Builder;
+import de.ii.ogcapi.features.core.domain.Profile;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
 import de.ii.ogcapi.foundation.domain.ApiRequestContext;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
@@ -270,6 +271,10 @@ public class EndpointFeatures extends EndpointFeaturesDefinition {
     QueryParameterSet queryParameterSet =
         QueryParameterSet.of(parameterDefinitions, toFlatMap(uriInfo.getQueryParameters()))
             .evaluate(api, Optional.of(collectionData));
+    Optional<Profile> profile =
+        Optional.ofNullable(
+            (Profile)
+                queryParameterSet.getTypedValues().get(QueryParameterProfileFeatures.PROFILE));
 
     FeatureQuery query =
         ogcApiFeaturesQuery.requestToFeatureQuery(
@@ -284,7 +289,7 @@ public class EndpointFeatures extends EndpointFeaturesDefinition {
             .from(getGenericQueryInput(api.getData()))
             .collectionId(collectionId)
             .query(query)
-            .profile(QueryParameterProfileFeatures.evaluate(queryParameterSet))
+            .profile(profile)
             .featureProvider(providers.getFeatureProviderOrThrow(api.getData(), collectionData))
             .defaultCrs(coreConfiguration.getDefaultEpsgCrs())
             .defaultPageSize(Optional.of(defaultPageSize))

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
@@ -217,7 +217,7 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
       String featureId,
       QueryInput queryInput,
       FeatureQuery query,
-      Profile requestedProfile,
+      Optional<Profile> requestedProfile,
       FeatureProvider2 featureProvider,
       String canonicalUri,
       FeatureFormatExtension outputFormat,
@@ -232,10 +232,7 @@ public class FeaturesCoreQueriesHandlerImpl implements FeaturesCoreQueriesHandle
     QueriesHandler.ensureFeatureProviderSupportsQueries(featureProvider);
 
     // negotiate profile, if the format does not support the selected profile
-    Profile profile =
-        outputFormat.supportsProfile(requestedProfile)
-            ? requestedProfile
-            : outputFormat.negotiateProfile(requestedProfile);
+    Optional<Profile> profile = requestedProfile.map(outputFormat::negotiateProfile);
 
     Optional<CrsTransformer> crsTransformer = Optional.empty();
 

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterBbox.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterBbox.java
@@ -46,6 +46,7 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -116,6 +117,10 @@ public class QueryParameterBbox extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
     FeatureTypeConfigurationOgcApi collectionData =
         optionalCollectionData.orElseThrow(
             () ->

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterDatetime.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterDatetime.java
@@ -34,6 +34,7 @@ import de.ii.xtraplatform.features.domain.FeatureSchema;
 import de.ii.xtraplatform.features.domain.Tuple;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -75,6 +76,11 @@ public class QueryParameterDatetime extends AbstractQueryParameterDatetime
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     FeatureTypeConfigurationOgcApi collectionData =
         optionalCollectionData.orElseThrow(
             () ->

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterOffsetFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterOffsetFeatures.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -66,7 +67,7 @@ public class QueryParameterOffsetFeatures extends ApiExtensionCache
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
     try {
-      return Integer.parseInt(value);
+      return Objects.nonNull(value) ? Integer.parseInt(value) : 0;
     } catch (Throwable e) {
       throw new IllegalArgumentException(
           String.format(

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterProfileFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterProfileFeatures.java
@@ -10,19 +10,19 @@ package de.ii.ogcapi.features.core.app;
 import com.github.azahnen.dagger.annotations.AutoBind;
 import de.ii.ogcapi.common.domain.QueryParameterProfile;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
+import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
 import de.ii.ogcapi.features.core.domain.Profile;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
 import de.ii.ogcapi.foundation.domain.ExtensionRegistry;
 import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
 import de.ii.ogcapi.foundation.domain.OgcApi;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
-import de.ii.ogcapi.foundation.domain.QueryParameterSet;
 import de.ii.ogcapi.foundation.domain.SchemaValidator;
 import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
+import de.ii.xtraplatform.features.domain.SchemaBase;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -52,10 +52,15 @@ import javax.inject.Singleton;
 public class QueryParameterProfileFeatures extends QueryParameterProfile
     implements TypedQueryParameter<Profile> {
 
+  private final FeaturesCoreProviders providers;
+
   @Inject
   public QueryParameterProfileFeatures(
-      ExtensionRegistry extensionRegistry, SchemaValidator schemaValidator) {
+      ExtensionRegistry extensionRegistry,
+      SchemaValidator schemaValidator,
+      FeaturesCoreProviders providers) {
     super(extensionRegistry, schemaValidator);
+    this.providers = providers;
   }
 
   @Override
@@ -65,8 +70,9 @@ public class QueryParameterProfileFeatures extends QueryParameterProfile
 
   @Override
   protected boolean isApplicable(OgcApiDataV2 apiData, String definitionPath) {
-    return definitionPath.equals("/collections/{collectionId}/items")
-        || definitionPath.equals("/collections/{collectionId}/items/{featureId}");
+    return (definitionPath.equals("/collections/{collectionId}/items")
+            || definitionPath.equals("/collections/{collectionId}/items/{featureId}"))
+        && usesFeatureRef(apiData);
   }
 
   @Override
@@ -115,9 +121,16 @@ public class QueryParameterProfileFeatures extends QueryParameterProfile
     }
   }
 
-  public static Profile evaluate(QueryParameterSet queryParameterSet) {
-    return (Profile)
-        Objects.requireNonNullElse(
-            queryParameterSet.getTypedValues().get(PROFILE), Profile.getDefault());
+  private boolean usesFeatureRef(OgcApiDataV2 apiData) {
+    return apiData.getCollections().values().stream()
+        .anyMatch(
+            collectionData ->
+                providers
+                    .getFeatureSchema(apiData, collectionData)
+                    .map(
+                        schema ->
+                            schema.getAllNestedProperties().stream()
+                                .anyMatch(SchemaBase::isFeatureRef))
+                    .orElse(false));
   }
 }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterProfileFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueryParameterProfileFeatures.java
@@ -92,6 +92,10 @@ public class QueryParameterProfileFeatures extends QueryParameterProfile
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    if (value == null) {
+      return Profile.getDefault();
+    }
+
     switch (value) {
       case "rel-as-key":
         return Profile.AS_KEY;

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureFormatExtension.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureFormatExtension.java
@@ -100,13 +100,13 @@ public interface FeatureFormatExtension extends FormatExtension {
   default Optional<PropertyTransformations> getPropertyTransformations(
       FeatureTypeConfigurationOgcApi collectionData,
       Optional<FeatureSchema> schema,
-      Profile profile) {
-    if (schema.isEmpty()) {
+      Optional<Profile> profile) {
+    if (profile.isEmpty() || schema.isEmpty()) {
       return getPropertyTransformations(collectionData);
     }
 
     ImmutableProfileTransformations.Builder builder = new ImmutableProfileTransformations.Builder();
-    switch (profile) {
+    switch (profile.get()) {
       default:
       case AS_KEY:
         // nothing to transform
@@ -134,7 +134,6 @@ public interface FeatureFormatExtension extends FormatExtension {
                                                         .stringFormat(template)
                                                         .build())))));
     }
-
     ProfileTransformations profileTransformations = builder.build();
     return Optional.of(
         getPropertyTransformations(collectionData)

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureLinksGenerator.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureLinksGenerator.java
@@ -22,7 +22,7 @@ public class FeatureLinksGenerator extends DefaultLinksGenerator {
 
   public List<Link> generateLinks(
       URICustomizer uriBuilder,
-      Profile profile,
+      Optional<Profile> profile,
       ApiMediaType mediaType,
       List<ApiMediaType> alternateMediaTypes,
       ApiMediaType collectionMediaType,
@@ -56,12 +56,14 @@ public class FeatureLinksGenerator extends DefaultLinksGenerator {
             .title(i18n.get("collectionLink", language))
             .build());
 
-    builder.add(
-        new ImmutableLink.Builder()
-            .href(profile.getUri())
-            .rel("profile")
-            .title(i18n.get("profileLink", language))
-            .build());
+    profile.ifPresent(
+        p ->
+            builder.add(
+                new ImmutableLink.Builder()
+                    .href(p.getUri())
+                    .rel("profile")
+                    .title(i18n.get("profileLink", language))
+                    .build()));
 
     return builder.build();
   }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreQueriesHandler.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesCoreQueriesHandler.java
@@ -35,7 +35,7 @@ public interface FeaturesCoreQueriesHandler
 
     FeatureQuery getQuery();
 
-    Profile getProfile();
+    Optional<Profile> getProfile();
 
     FeatureProvider2 getFeatureProvider();
 
@@ -64,7 +64,7 @@ public interface FeaturesCoreQueriesHandler
 
     FeatureQuery getQuery();
 
-    Profile getProfile();
+    Optional<Profile> getProfile();
 
     FeatureProvider2 getFeatureProvider();
 

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesLinksGenerator.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeaturesLinksGenerator.java
@@ -25,7 +25,7 @@ public class FeaturesLinksGenerator extends DefaultLinksGenerator {
       int offset,
       int limit,
       int defaultLimit,
-      Profile profile,
+      Optional<Profile> profile,
       ApiMediaType mediaType,
       List<ApiMediaType> alternateMediaTypes,
       I18n i18n,
@@ -62,12 +62,14 @@ public class FeaturesLinksGenerator extends DefaultLinksGenerator {
               .title(i18n.get("firstLink", language))
               .build());
     }
-    builder.add(
-        new ImmutableLink.Builder()
-            .href(profile.getUri())
-            .rel("profile")
-            .title(i18n.get("profileLink", language))
-            .build());
+    profile.ifPresent(
+        p ->
+            builder.add(
+                new ImmutableLink.Builder()
+                    .href(p.getUri())
+                    .rel("profile")
+                    .title(i18n.get("profileLink", language))
+                    .build()));
 
     return builder.build();
   }

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/QueryParameterDebugFeaturesGeoJson.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/QueryParameterDebugFeaturesGeoJson.java
@@ -22,6 +22,7 @@ import de.ii.xtraplatform.base.domain.AppContext;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -62,7 +63,7 @@ public class QueryParameterDebugFeaturesGeoJson extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return Boolean.parseBoolean(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/QueryParameterPrettyFeaturesGeoJson.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/QueryParameterPrettyFeaturesGeoJson.java
@@ -22,6 +22,7 @@ import de.ii.xtraplatform.base.domain.AppContext;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -61,7 +62,7 @@ public class QueryParameterPrettyFeaturesGeoJson extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
-    return Boolean.parseBoolean(value);
+    return Objects.nonNull(value) && Boolean.parseBoolean(value);
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
@@ -258,8 +258,8 @@ public class FeaturesFormatGml implements ConformanceClass, FeatureFormatExtensi
   public Optional<PropertyTransformations> getPropertyTransformations(
       FeatureTypeConfigurationOgcApi collectionData,
       Optional<FeatureSchema> schema,
-      Profile profile) {
-    if (schema.isEmpty()) {
+      Optional<Profile> profile) {
+    if (profile.isEmpty() || schema.isEmpty()) {
       return getPropertyTransformations(collectionData);
     }
 

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
@@ -173,13 +173,13 @@ public class FeaturesFormatHtml
   public Optional<PropertyTransformations> getPropertyTransformations(
       FeatureTypeConfigurationOgcApi collectionData,
       Optional<FeatureSchema> schema,
-      Profile profile) {
-    if (schema.isEmpty()) {
+      Optional<Profile> profile) {
+    if (profile.isEmpty() || schema.isEmpty()) {
       return getPropertyTransformations(collectionData);
     }
 
     ImmutableProfileTransformations.Builder builder = new ImmutableProfileTransformations.Builder();
-    switch (profile) {
+    switch (profile.get()) {
       default:
       case AS_KEY:
         return getPropertyTransformations(collectionData);

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueryParameterSet.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueryParameterSet.java
@@ -48,8 +48,7 @@ public interface QueryParameterSet {
     for (int pass = 1; pass <= numberOfParsingPasses; pass++) {
       for (OgcApiQueryParameter parameter : getDefinitions()) {
         if (parameter instanceof TypedQueryParameter<?>
-            && ((TypedQueryParameter<?>) parameter).getPriority() == pass
-            && values.containsKey(parameter.getName())) {
+            && ((TypedQueryParameter<?>) parameter).getPriority() == pass) {
           Object parsedValue =
               ((TypedQueryParameter<?>) parameter)
                   .parse(values.get(parameter.getName()), typedValues, api, optionalCollectionData);

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterCollections.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterCollections.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -142,6 +143,11 @@ public class QueryParameterCollections extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     try {
       List<String> collections = getCollectionIds(api.getData());
       return Splitter.on(',').omitEmptyStrings().trimResults().splitToList(value).stream()

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterDatetimeTile.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterDatetimeTile.java
@@ -31,6 +31,7 @@ import de.ii.xtraplatform.tiles.domain.ImmutableTileGenerationParametersTransien
 import de.ii.xtraplatform.tiles.domain.TileGenerationSchema;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -91,6 +92,11 @@ public class QueryParameterDatetimeTile extends AbstractQueryParameterDatetime
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
+    if (Objects.isNull(value)) {
+      // no default value
+      return null;
+    }
+
     try {
       if (value.contains(DATETIME_INTERVAL_SEPARATOR)) {
         return TemporalLiteral.of(Splitter.on(DATETIME_INTERVAL_SEPARATOR).splitToList(value));

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterLimitTile.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/QueryParameterLimitTile.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -159,6 +160,22 @@ public class QueryParameterLimitTile extends ApiExtensionCache
       Map<String, Object> typedValues,
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> collectionData) {
+    if (Objects.isNull(value)) {
+      return collectionData
+          .flatMap(
+              cd ->
+                  tilesProviders
+                      .getTileProvider(api.getData(), cd)
+                      .map(TileProvider::getData)
+                      .map(TileProviderData::getTilesetDefaults)
+                      .filter(defaults -> defaults instanceof TileGenerationOptions)
+                      .flatMap(
+                          defaults ->
+                              Optional.ofNullable(
+                                  ((TileGenerationOptions) defaults).getFeatureLimit())))
+          .orElse(null);
+    }
+
     try {
       return Integer.parseInt(value);
     } catch (Throwable e) {


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Query parameters can have default values. Some `TypedQueryParameter` classes implemented the `parse()` method already to return the default value, if no value was provided with the request. However, most classes did not handle a `null` value and `parse()` was not executed for query parameters without a value. The result was that default values had to be taken care of separately.

This has been addressed:

- `QueryParameterSet.evaluate()` now also calls `parse()` for query parameters without a value.
- `parse()` now handles `null` values for all `TypedQueryParameter` classes.

This change is part of #846.