### PR TITLE
Tiles: Address comments/issues from the OGC June 2023 Code Sprint

### DIFF
--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesLinkGenerator.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesLinkGenerator.java
@@ -211,7 +211,11 @@ public class TilesLinkGenerator extends DefaultLinksGenerator {
    * @return a list with links
    */
   public List<Link> generateCollectionLinks(
-      URICustomizer uriBuilder, DataType dataType, I18n i18n, Optional<Locale> language) {
+      URICustomizer uriBuilder,
+      String collectionId,
+      DataType dataType,
+      I18n i18n,
+      Optional<Locale> language) {
 
     return ImmutableList.<Link>builder()
         .add(
@@ -220,7 +224,8 @@ public class TilesLinkGenerator extends DefaultLinksGenerator {
                     uriBuilder
                         .copy()
                         .ensureNoTrailingSlash()
-                        .ensureLastPathSegment("tiles")
+                        .ensureLastPathSegment(collectionId)
+                        .ensureLastPathSegments("tiles")
                         .removeParameters("f")
                         .toString())
                 .rel("http://www.opengis.net/def/rel/ogc/1.0/tilesets-" + dataType.toString())

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnCollection.java
@@ -59,8 +59,7 @@ public class TilesOnCollection implements CollectionExtension {
     // The hrefs are URI templates and not URIs, so the templates should not be percent encoded!
     final TilesLinkGenerator tilesLinkGenerator = new TilesLinkGenerator();
 
-    if (!isNested
-        && isExtensionEnabled(featureTypeConfiguration, TilesConfiguration.class)
+    if (isExtensionEnabled(featureTypeConfiguration, TilesConfiguration.class)
         && isExtensionEnabled(
             featureTypeConfiguration,
             TilesConfiguration.class,
@@ -83,7 +82,7 @@ public class TilesOnCollection implements CollectionExtension {
 
       collection.addAllLinks(
           tilesLinkGenerator.generateCollectionLinks(
-              uriCustomizer, dataType.get(), i18n, language));
+              uriCustomizer, featureTypeConfiguration.getId(), dataType.get(), i18n, language));
     }
 
     return collection;

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
@@ -39,7 +39,6 @@ import de.ii.ogcapi.tiles.domain.ImmutableTileSets;
 import de.ii.ogcapi.tiles.domain.ImmutableTileSets.Builder;
 import de.ii.ogcapi.tiles.domain.TileFormatExtension;
 import de.ii.ogcapi.tiles.domain.TileGenerationUserParameter;
-import de.ii.ogcapi.tiles.domain.TileLayer;
 import de.ii.ogcapi.tiles.domain.TileSet;
 import de.ii.ogcapi.tiles.domain.TileSet.DataType;
 import de.ii.ogcapi.tiles.domain.TileSetFormatExtension;
@@ -583,15 +582,15 @@ public class TilesQueriesHandlerImpl implements TilesQueriesHandler {
                 .orElse(SimpleFeatureGeometry.ANY)) {
               case POINT:
               case MULTI_POINT:
-                builder2.geometryType(TileLayer.GeometryType.points);
+                builder2.geometryDimension(0);
                 break;
               case LINE_STRING:
               case MULTI_LINE_STRING:
-                builder2.geometryType(TileLayer.GeometryType.lines);
+                builder2.geometryDimension(1);
                 break;
               case POLYGON:
               case MULTI_POLYGON:
-                builder2.geometryType(TileLayer.GeometryType.polygons);
+                builder2.geometryDimension(2);
                 break;
             }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/html/TileSetsView.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/html/TileSetsView.java
@@ -24,7 +24,6 @@ import de.ii.ogcapi.html.domain.MapClient.Popup;
 import de.ii.ogcapi.html.domain.MapClient.Source.TYPE;
 import de.ii.ogcapi.html.domain.MapClient.Type;
 import de.ii.ogcapi.html.domain.OgcApiView;
-import de.ii.ogcapi.tiles.domain.TileLayer.GeometryType;
 import de.ii.ogcapi.tiles.domain.TilePoint;
 import de.ii.ogcapi.tiles.domain.TileSet;
 import de.ii.ogcapi.tiles.domain.TileSet.DataType;
@@ -51,6 +50,9 @@ import org.slf4j.LoggerFactory;
 @Value.Immutable
 public abstract class TileSetsView extends OgcApiView {
   private static final Logger LOGGER = LoggerFactory.getLogger(TileSetsView.class);
+
+  private static final Map<Integer, String> GEOMETRY_TYPES =
+      ImmutableMap.of(0, "points", 1, "lines", 2, "polygons");
 
   public abstract I18n i18n();
 
@@ -410,15 +412,19 @@ public abstract class TileSetsView extends OgcApiView {
         .filter(layer -> layer.getDataType() == DataType.vector)
         .map(
             layer ->
-                layer.getGeometryType().isPresent()
-                    ? new SimpleImmutableEntry<>(
-                        layer.getId(), ImmutableList.of(layer.getGeometryType().get().name()))
-                    : new SimpleImmutableEntry<>(
-                        layer.getId(),
-                        ImmutableList.of(
-                            GeometryType.points.name(),
-                            GeometryType.lines.name(),
-                            GeometryType.polygons.name())))
+                layer
+                    .getGeometryDimension()
+                    .map(
+                        dim ->
+                            new SimpleImmutableEntry<>(
+                                layer.getId(), ImmutableList.of(GEOMETRY_TYPES.get(dim))))
+                    .orElse(
+                        new SimpleImmutableEntry<>(
+                            layer.getId(),
+                            ImmutableList.of(
+                                GEOMETRY_TYPES.get(0),
+                                GEOMETRY_TYPES.get(1),
+                                GEOMETRY_TYPES.get(2)))))
         .collect(
             ImmutableSetMultimap.toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue));
   }

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileLayer.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileLayer.java
@@ -23,19 +23,13 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTileLayer.class)
 public abstract class TileLayer extends OgcResourceMetadata {
 
-  public enum GeometryType {
-    points,
-    lines,
-    polygons
-  }
-
   public abstract String getId();
 
   public abstract TileSet.DataType getDataType();
 
   public abstract Optional<String> getFeatureType();
 
-  public abstract Optional<GeometryType> getGeometryType();
+  public abstract Optional<Integer> getGeometryDimension();
 
   public abstract Optional<String> getTheme();
 
@@ -65,8 +59,7 @@ public abstract class TileLayer extends OgcResourceMetadata {
         into.putString(from.getId(), StandardCharsets.UTF_8);
         into.putString(from.getDataType().toString(), StandardCharsets.UTF_8);
         from.getFeatureType().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
-        from.getGeometryType()
-            .ifPresent(val -> into.putString(val.toString(), StandardCharsets.UTF_8));
+        from.getGeometryDimension().ifPresent(into::putInt);
         from.getTheme().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
         from.getMinTileMatrix().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
         from.getMaxTileMatrix().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.3.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.2.0-${platform}"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.3.0-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.3.0-fix-tiles-SNAPSHOT'
 }
 

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,6 +2,6 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.3.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.2.0-${platform}"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.3.0-fix-tiles-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '6.3.0-SNAPSHOT'
 }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Bugs:

- `geometryType` -> `geometryDimension`: Tileset metadata in the released standard uses `geometryDimension`, not any more `geometryType`. This was missed in the update to OGC API Tiles 1.0 / TMS 2.0. 

Bugs or Improvements (depends on discussions in the SWG):

- Add `tilesets-*` links on `/collections`: It was apparently the intention to require these links not only on each collection resource, but also if the collections are embedded in the collections array. 

Improvements:

- Improve tile geometry validity
  - If a tile geometry is invalid, continue to try to fix it, but reduce the result again to the tile grid. Stop after two attempts.
- Small improvements 
  - If determining a "full" tile fails, simply ignore the exception and assume false.
  - Log the error message for invalid tile geometries.

Two of the four changes are addressed in https://github.com/interactive-instruments/xtraplatform-spatial/pull/212.