### PR TITLE
fix issues in the derived style for feature(s)

### DIFF
--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/index.jsx
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { useMaplibreUIEffect } from "react-maplibre-ui";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import combine from "@turf/combine";
-import { geoJsonLayers, hoverLayers, vectorLayers } from "../styles";
+import { geoJsonLayers, hoverLayers, vectorLayers, isDataLayer } from "../styles";
 import { getBounds, getFeaturesWithIdAsProperty, idProperty } from "../geojson";
 import { addPopup, addPopupProps } from "./popup";
 
@@ -29,7 +29,7 @@ const setStyleGeoJson = (map, styleUrl, removeZoomLevelConstraints) => {
           ...baseStyle.sources,
         },
         layers: style.layers.map((layer) => {
-          if (layer.type !== "raster") {
+          if (isDataLayer(layer)) {
             const newLayer = {
               ...layer,
               source: "data",
@@ -49,13 +49,14 @@ const setStyleGeoJson = (map, styleUrl, removeZoomLevelConstraints) => {
       if (dataStyle.sources.data) {
         dataStyle.sources.data.attribution = style.layers
           .filter(
-            (layer) =>
-              layer.type !== "raster" && style.sources[layer.source].attribution
+            (layer) => isDataLayer(layer) && style.sources[layer.source].attribution
           )
           .map((layer) => style.sources[layer.source].attribution)
           .filter((v, i, a) => a.indexOf(v) === i)
           .join(" | ");
       }
+
+      delete dataStyle.terrain;
 
       map.setStyle(dataStyle, { diff: false });
     });
@@ -104,7 +105,7 @@ const setStyleVector = (
           layers: style.layers
             .filter(
               (layer) =>
-                layer.type === "raster" ||
+                !isDataLayer(layer) ||
                 (layer["source-layer"] &&
                   (sourceLayers.length === 0 ||
                     sourceLayers.includes(layer["source-layer"])))
@@ -132,7 +133,7 @@ const setStyleVector = (
           map,
           maplibre,
           dataStyle.layers
-            .filter((layer) => layer.type !== "raster")
+            .filter((layer) => isDataLayer(layer) === true)
             .map((layer) => layer.id)
         );
       }

--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/styles.js
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/styles.js
@@ -41,6 +41,17 @@ export const baseStyle = (url, attribution, defaultUrl, defaultAttribution) => {
 
 export const hoverLayers = ["points", "lines", "polygons"];
 
+export const isDataLayer = (layer) => {
+  switch (layer.type) {
+    case "raster":
+    case "hillshade":
+    case "background":
+      return false;
+    default:
+      return true;
+  }
+};
+
 const circleLayers = (color, opacity, circleRadius, minZoom, maxZoom) => [
   {
     id: "points",


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

This is a follow-up to PR #1024 that added support for terrain in MapLibre styles. It turned out that for some reason, using a terrain in a default style led to JavaScript errors when displaying features with the derived style. This change removes terrains from the derived styles for the GeoJSON features.

In addition, hillshade and background layers were not properly handled when a style for the GeoJSON features were derived for displaying feature(s) in the HTML representation.
