### PR TITLE
3D Tiles: fix ApiRequestContext building

### DIFF
--- a/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/app/Tiles3dContentUtil.java
+++ b/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/app/Tiles3dContentUtil.java
@@ -103,6 +103,7 @@ public final class Tiles3dContentUtil {
                 .addParameter("filter", contentFilterString)
                 .addParameter("clampToEllipsoid", String.valueOf(cfg.shouldClampToEllipsoid()))
                 .build())
+        .externalUri(uriCustomizer.copy().removeLastPathSegments(4).clearParameters().build())
         .mediaType(Format3dTilesContentGltfBinary.MEDIA_TYPE)
         .alternateMediaTypes(ImmutableList.of())
         .build();

--- a/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/Subtree.java
+++ b/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/Subtree.java
@@ -503,6 +503,7 @@ public interface Subtree {
                             "/",
                             ImmutableList.of(
                                 "collections", queryInput.getCollectionId(), "items"))))
+            .externalUri(queryInput.getServicesUri())
             .build();
 
     return getNumberReturned(queriesHandler, queryInputHits, requestContext) == 1L;


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

A new member `externalUri` was introduced in ApiRequestContext in #1047, but the use in 3D Tiles was not updated.
