### PR TITLE
exclude formats with getContent()=null from f

### DIFF
--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterF.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterF.java
@@ -100,6 +100,7 @@ public abstract class QueryParameterF extends ApiExtensionCache
       List<String> fEnum = new ArrayList<>();
       extensionRegistry.getExtensionsForType(getFormatClass()).stream()
           .filter(f -> f.isEnabledForApi(apiData))
+          .filter(f -> Objects.nonNull(f.getContent()))
           .filter(f -> !f.getMediaType().parameter().equals("*"))
           .map(f -> f.getMediaType().parameter())
           .distinct()
@@ -118,6 +119,7 @@ public abstract class QueryParameterF extends ApiExtensionCache
       List<String> fEnum = new ArrayList<>();
       extensionRegistry.getExtensionsForType(getFormatClass()).stream()
           .filter(f -> f.isEnabledForApi(apiData, collectionId))
+          .filter(f -> Objects.nonNull(f.getContent()))
           .filter(f -> !f.getMediaType().parameter().equals("*"))
           .map(f -> f.getMediaType().parameter())
           .distinct()


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

`EndpointExtenson.getMediaTypes()` excludes these (internal) formats, e.g., `pap`. However, currently `pap` is included in the list of values in the `f` parameter for features, but it is not a supported media type in the API.
