### PR TITLE
Tiles: deprecate datasetTiles, collectionTiles

### DIFF
--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetMultiCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetMultiCollection.java
@@ -54,7 +54,7 @@ public abstract class AbstractEndpointTileSetMultiCollection extends Endpoint {
     return apiData
         .getExtension(TilesConfiguration.class)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasDatasetTiles)
+        .filter(cfg -> cfg.hasDatasetTiles(null, apiData))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetSingleCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetSingleCollection.java
@@ -77,7 +77,7 @@ public abstract class AbstractEndpointTileSetSingleCollection extends EndpointSu
         .getCollectionData(collectionId)
         .flatMap(cfg -> cfg.getExtension(TilesConfiguration.class))
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasCollectionTiles)
+        .filter(cfg -> cfg.hasCollectionTiles(tilesProviders, apiData, collectionId))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetsMultiCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetsMultiCollection.java
@@ -52,7 +52,7 @@ public abstract class AbstractEndpointTileSetsMultiCollection extends Endpoint {
     return apiData
         .getExtension(TilesConfiguration.class)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasDatasetTiles)
+        .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetsSingleCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetsSingleCollection.java
@@ -70,7 +70,7 @@ public abstract class AbstractEndpointTileSetsSingleCollection extends EndpointS
         .getCollectionData(collectionId)
         .flatMap(cfg -> cfg.getExtension(TilesConfiguration.class))
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasCollectionTiles)
+        .filter(cfg -> cfg.hasCollectionTiles(tilesProviders, apiData, collectionId))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnCollection.java
@@ -21,6 +21,7 @@ import de.ii.ogcapi.foundation.domain.URICustomizer;
 import de.ii.ogcapi.tiles.domain.TileFormatExtension;
 import de.ii.ogcapi.tiles.domain.TileSet.DataType;
 import de.ii.ogcapi.tiles.domain.TilesConfiguration;
+import de.ii.ogcapi.tiles.domain.TilesProviders;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -34,11 +35,14 @@ public class TilesOnCollection implements CollectionExtension {
 
   private final I18n i18n;
   private final ExtensionRegistry extensionRegistry;
+  private final TilesProviders tilesProviders;
 
   @Inject
-  public TilesOnCollection(I18n i18n, ExtensionRegistry extensionRegistry) {
+  public TilesOnCollection(
+      I18n i18n, ExtensionRegistry extensionRegistry, TilesProviders tilesProviders) {
     this.i18n = i18n;
     this.extensionRegistry = extensionRegistry;
+    this.tilesProviders = tilesProviders;
   }
 
   @Override
@@ -63,7 +67,9 @@ public class TilesOnCollection implements CollectionExtension {
         && isExtensionEnabled(
             featureTypeConfiguration,
             TilesConfiguration.class,
-            TilesConfiguration::hasCollectionTiles)) {
+            cfg ->
+                cfg.hasCollectionTiles(
+                    tilesProviders, api.getData(), featureTypeConfiguration.getId()))) {
       Optional<DataType> dataType =
           extensionRegistry.getExtensionsForType(TileFormatExtension.class).stream()
               .filter(

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnLandingPage.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesOnLandingPage.java
@@ -22,6 +22,7 @@ import de.ii.ogcapi.foundation.domain.URICustomizer;
 import de.ii.ogcapi.tiles.domain.TileFormatExtension;
 import de.ii.ogcapi.tiles.domain.TileSet.DataType;
 import de.ii.ogcapi.tiles.domain.TilesConfiguration;
+import de.ii.ogcapi.tiles.domain.TilesProviders;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -35,11 +36,14 @@ public class TilesOnLandingPage implements LandingPageExtension {
 
   private final I18n i18n;
   private final ExtensionRegistry extensionRegistry;
+  private final TilesProviders tilesProviders;
 
   @Inject
-  public TilesOnLandingPage(I18n i18n, ExtensionRegistry extensionRegistry) {
+  public TilesOnLandingPage(
+      I18n i18n, ExtensionRegistry extensionRegistry, TilesProviders tilesProviders) {
     this.i18n = i18n;
     this.extensionRegistry = extensionRegistry;
+    this.tilesProviders = tilesProviders;
   }
 
   @Override
@@ -48,7 +52,7 @@ public class TilesOnLandingPage implements LandingPageExtension {
 
     return extension
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasDatasetTiles)
+        .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/PathParameterTileMatrixSetId.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/PathParameterTileMatrixSetId.java
@@ -69,7 +69,7 @@ public class PathParameterTileMatrixSetId implements OgcApiPathParameter {
         apiData
             .getExtension(TilesConfiguration.class)
             .filter(TilesConfiguration::isEnabled)
-            .filter(TilesConfiguration::hasDatasetTiles)
+            .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
             .flatMap(cfg -> tilesProviders.getTilesetMetadata(apiData))
             .map(TilesetMetadata::getTileMatrixSets)
             .orElse(ImmutableSet.of())

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileFormatExtension.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileFormatExtension.java
@@ -27,7 +27,7 @@ public abstract class TileFormatExtension implements FormatExtension {
     return apiData
         .getExtension(TilesConfiguration.class)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasDatasetTiles)
+        .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
         .filter(
             config ->
                 tilesProviders
@@ -42,7 +42,7 @@ public abstract class TileFormatExtension implements FormatExtension {
     return apiData
         .getExtension(TilesConfiguration.class, collectionId)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasCollectionTiles)
+        .filter(cfg -> cfg.hasCollectionTiles(tilesProviders, apiData, collectionId))
         .filter(
             config ->
                 tilesProviders

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileGenerationUserParameter.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TileGenerationUserParameter.java
@@ -28,7 +28,7 @@ public interface TileGenerationUserParameter {
         apiData
             .getExtension(TilesConfiguration.class)
             .filter(TilesConfiguration::isEnabled)
-            .filter(TilesConfiguration::hasDatasetTiles);
+            .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData));
     Optional<de.ii.xtraplatform.tiles.domain.TileProvider> tileProvider =
         tilesProviders
             .getTileProvider(apiData)
@@ -44,7 +44,7 @@ public interface TileGenerationUserParameter {
             .getCollectionData(collectionId)
             .flatMap(cd -> cd.getExtension(TilesConfiguration.class))
             .filter(TilesConfiguration::isEnabled)
-            .filter(TilesConfiguration::hasCollectionTiles);
+            .filter(cfg -> cfg.hasCollectionTiles(tilesProviders, apiData, collectionId));
     Optional<de.ii.xtraplatform.tiles.domain.TileProvider> tileProvider =
         tilesProviders
             .getTileProvider(apiData, apiData.getCollectionData(collectionId))

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
@@ -541,11 +541,13 @@ public interface TilesConfiguration extends SfFlatConfiguration, CachingConfigur
   }
 
   /**
-   * @langEn **Deprecated** Enable vector tiles for each *Feature Collection*. Every tile contains a
-   *     layer with the feature from the collection. If a Tile Provider is specified, tiles will
-   *     always be enabled for a collection, if the tileset is specified in the Tile Provider,
-   *     independent of the value of this option.
-   * @langDe **Deprecated** Steuert, ob Vector Tiles für jede Feature Collection aktiviert werden
+   * @langEn *Deprecated (from v4.0 on you have to use [Tile
+   *     Provider](../../providers/tile/README.md) entities)* Enable vector tiles for each *Feature
+   *     Collection*. Every tile contains a layer with the feature from the collection. If a Tile
+   *     Provider is specified, tiles will always be enabled for a collection, if the tileset is
+   *     specified in the Tile Provider, independent of the value of this option.
+   * @langDe *Deprecated (ab v4.0 müssen [Tile-Provider](../../providers/tile/README.md) Entities
+   *     verwendet werden)* Steuert, ob Vector Tiles für jede Feature Collection aktiviert werden
    *     sollen. Jede Kachel hat einen Layer mit den Features aus der Collection. Wenn ein
    *     Tile-Provider spezifiziert ist, dann werden - unabhängig von dieser Option - Kacheln für
    *     eine Collection genau dann aktiviert, wenn das Tileset im Tile Provider spezifiziert ist.
@@ -577,11 +579,14 @@ public interface TilesConfiguration extends SfFlatConfiguration, CachingConfigur
   }
 
   /**
-   * @langEn **Deprecated** Enable vector tiles for the whole dataset. Every tile contains one layer
-   *     per collection with the features of that collection. If a Tile Provider is specified, tiles
-   *     will always be enabled for the dataset, if the corresponding tileset is specified in the
-   *     Tile Provider, independent of the value of this option.
-   * @langDe **Deprecated** Steuert, ob Vector Tiles auf Ebene des Datensatzes aktiviert werden
+   * @langEn *Deprecated (from v4.0 on you have to use [Tile
+   *     Provider](../../providers/tile/README.md) entities)* Enable vector tiles for the whole
+   *     dataset. Every tile contains one layer per collection with the features of that collection.
+   *     If a Tile Provider is specified, tiles will always be enabled for the dataset, if the
+   *     corresponding tileset is specified in the Tile Provider, independent of the value of this
+   *     option.
+   * @langDe *Deprecated (ab v4.0 müssen [Tile-Provider](../../providers/tile/README.md) Entities
+   *     verwendet werden)* Steuert, ob Vector Tiles auf Ebene des Datensatzes aktiviert werden
    *     sollen. Jede Kachel hat einen Layer pro Collection mit den Features aus der Collection.
    *     Wenn ein Tile-Provider spezifiziert ist, dann werden - unabhängig von dieser Option -
    *     Kacheln für Datensatz genau dann aktiviert, wenn das entsprechende Tileset im Tile Provider

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesMigrationV4.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesMigrationV4.java
@@ -194,13 +194,14 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
     Map<String, FeatureTypeConfigurationOgcApi> collections =
         apiData.getCollections().entrySet().stream()
             .filter(
-                entry ->
-                    entry
-                        .getValue()
-                        .getExtension(TilesConfiguration.class)
-                        .filter(TilesConfiguration::isEnabled)
-                        .filter(TilesConfiguration::hasCollectionTiles)
-                        .isPresent())
+                entry -> {
+                  FeatureTypeConfigurationOgcApi collectionData = entry.getValue();
+                  return collectionData
+                      .getExtension(TilesConfiguration.class)
+                      .filter(TilesConfiguration::isEnabled)
+                      .filter(cfg -> cfg.hasCollectionTiles(null, apiData, collectionData.getId()))
+                      .isPresent();
+                })
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Objects.nonNull(tiles.get().getTileProvider())
@@ -247,7 +248,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                 .putAllLevels(tilesConfiguration.getZoomLevelsDerived())
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles()
+            tilesConfiguration.hasDatasetTiles(null, null)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetMbTiles.Builder()
@@ -311,7 +312,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                             ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles()
+            tilesConfiguration.hasDatasetTiles(null, null)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetHttp.Builder()
@@ -396,7 +397,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                         : Optional.empty())
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles()
+            tilesConfiguration.hasDatasetTiles(null, null)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetFeatures.Builder()

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileMultiCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileMultiCollection.java
@@ -77,7 +77,7 @@ public class EndpointTileMultiCollection extends Endpoint
     return apiData
         .getExtension(TilesConfiguration.class)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasDatasetTiles)
+        .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileSingleCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileSingleCollection.java
@@ -77,7 +77,7 @@ public class EndpointTileSingleCollection extends EndpointSubCollection
     return apiData
         .getExtension(TilesConfiguration.class, collectionId)
         .filter(TilesConfiguration::isEnabled)
-        .filter(TilesConfiguration::hasCollectionTiles)
+        .filter(cfg -> cfg.hasCollectionTiles(tilesProviders, apiData, collectionId))
         .isPresent();
   }
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Closes #1005.

If a tile provider exists, the provider is used to determine, which tilesets exist. Otherwise the deprecated options are used (until v4).

