### PR TITLE
typed query parameters: fix handling default values

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/TypedQueryParameter.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/TypedQueryParameter.java
@@ -35,7 +35,7 @@ public interface TypedQueryParameter<T> {
       OgcApi api,
       Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
     if (Objects.isNull(value) || value.isEmpty()) {
-      return null;
+      return parse((String) null, typedValues, api, optionalCollectionData);
     }
     return parse(value.get(0), typedValues, api, optionalCollectionData);
   }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

This is a follow-up to #1072, which did not properly handle the case, where no value was provided for a parameter in the request.
