### PR TITLE
Fix deprecated properties

### DIFF
--- a/ldproxy-cfg/src/main/java/de/ii/ldproxy/cfg/Migrations.java
+++ b/ldproxy-cfg/src/main/java/de/ii/ldproxy/cfg/Migrations.java
@@ -7,6 +7,7 @@
  */
 package de.ii.ldproxy.cfg;
 
+import de.ii.ogcapi.resources.app.StylesMigrationV4;
 import de.ii.ogcapi.text.search.app.QueryablesMigrationV4;
 import de.ii.ogcapi.tiles.domain.TilesMigrationV4;
 import de.ii.xtraplatform.entities.domain.EntityDataStore;
@@ -19,7 +20,11 @@ public interface Migrations {
   static Migrations create(EntityDataStore<?> entityDataStore) {
     EntityMigrationContext context = entityDataStore::has;
 
-    return () -> List.of(new TilesMigrationV4(context), new QueryablesMigrationV4(context));
+    return () ->
+        List.of(
+            new TilesMigrationV4(context),
+            new QueryablesMigrationV4(context),
+            new StylesMigrationV4(context));
   }
 
   List<EntityMigration<?, ?>> entity();

--- a/ogcapi-custom/ogcapi-resources/src/main/java/de/ii/ogcapi/resources/app/StylesMigrationV4.java
+++ b/ogcapi-custom/ogcapi-resources/src/main/java/de/ii/ogcapi/resources/app/StylesMigrationV4.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.resources.app;
+
+import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.ImmutableOgcApiDataV2;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
+import de.ii.ogcapi.html.domain.HtmlConfiguration;
+import de.ii.ogcapi.html.domain.ImmutableHtmlConfiguration;
+import de.ii.ogcapi.resources.domain.ImmutableResourcesConfiguration;
+import de.ii.ogcapi.resources.domain.ResourcesConfiguration;
+import de.ii.ogcapi.styles.domain.ImmutableStylesConfiguration;
+import de.ii.ogcapi.styles.domain.StylesConfiguration;
+import de.ii.xtraplatform.entities.domain.EntityData;
+import de.ii.xtraplatform.entities.domain.EntityMigration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class StylesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2> {
+
+  public StylesMigrationV4(EntityMigrationContext context) {
+    super(context);
+  }
+
+  @Override
+  public String getSubject() {
+    return "building block Styles, properties 'resourcesEnables', 'resourceManagerEnabled', and 'defaultStyle'";
+  }
+
+  @Override
+  public String getDescription() {
+    return "is deprecated and will be upgraded to the RESOURCES and HTML building blocks";
+  }
+
+  @Override
+  public boolean isApplicable(EntityData entityData, Optional<EntityData> defaults) {
+    if (!(entityData instanceof OgcApiDataV2)) {
+      return false;
+    }
+
+    OgcApiDataV2 apiData = (OgcApiDataV2) entityData;
+
+    for (FeatureTypeConfigurationOgcApi collection : apiData.getCollections().values()) {
+      Optional<StylesConfiguration> stylesConfiguration =
+          collection.getExtension(StylesConfiguration.class);
+
+      if (hasDeprecatedProperties(stylesConfiguration)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public OgcApiDataV2 migrate(OgcApiDataV2 entityData, Optional<OgcApiDataV2> defaults) {
+    Map<String, FeatureTypeConfigurationOgcApi> collections =
+        entityData.getCollections().entrySet().stream()
+            .map(
+                entry -> {
+                  FeatureTypeConfigurationOgcApi collectionOld = entry.getValue();
+                  Optional<StylesConfiguration> stylesConfigurationOld =
+                      collectionOld.getExtension(StylesConfiguration.class);
+                  Optional<ResourcesConfiguration> resourcesConfigurationOld =
+                      collectionOld.getExtension(ResourcesConfiguration.class);
+                  Optional<HtmlConfiguration> htmlConfigurationOld =
+                      collectionOld.getExtension(HtmlConfiguration.class);
+
+                  if (!hasDeprecatedProperties(stylesConfigurationOld)) {
+                    return Map.entry(entry.getKey(), collectionOld);
+                  }
+
+                  StylesConfiguration stylesConfiguration =
+                      new ImmutableStylesConfiguration.Builder()
+                          .from(stylesConfigurationOld.get())
+                          .resourcesEnabled(null)
+                          .resourceManagerEnabled(null)
+                          .defaultStyle(null)
+                          .build();
+
+                  // If a ResourcesConfiguration is already present, simply ignore the
+                  // deprecated values.
+                  ResourcesConfiguration resourcesConfiguration =
+                      resourcesConfigurationOld.isPresent()
+                          ? null
+                          : new ImmutableResourcesConfiguration.Builder()
+                              .enabled(stylesConfigurationOld.get().isResourcesEnabled())
+                              .managerEnabled(
+                                  stylesConfigurationOld.get().isResourceManagerEnabled())
+                              .build();
+
+                  // If a HtmlConfiguration exists with a defaultStyle value, simply ignore the
+                  // deprecated value.
+                  HtmlConfiguration htmlConfiguration =
+                      (Objects.isNull(stylesConfigurationOld.get().getDefaultStyle())
+                              || htmlConfigurationOld
+                                  .filter(cfg -> Objects.nonNull(cfg.getDefaultStyle()))
+                                  .isPresent())
+                          ? null
+                          : (htmlConfigurationOld.isPresent()
+                                  ? new ImmutableHtmlConfiguration.Builder()
+                                      .from(htmlConfigurationOld.get())
+                                  : new ImmutableHtmlConfiguration.Builder())
+                              .defaultStyle(stylesConfigurationOld.get().getDefaultStyle())
+                              .build();
+
+                  FeatureTypeConfigurationOgcApi collection =
+                      FeatureTypeConfigurationOgcApi.replaceOrAddExtensions(
+                          collectionOld,
+                          stylesConfiguration,
+                          resourcesConfiguration,
+                          htmlConfiguration);
+
+                  return Map.entry(entry.getKey(), collection);
+                })
+            .collect(
+                Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> b, LinkedHashMap::new));
+
+    return new ImmutableOgcApiDataV2.Builder().from(entityData).collections(collections).build();
+  }
+
+  private boolean hasDeprecatedProperties(Optional<StylesConfiguration> stylesConfiguration) {
+    return stylesConfiguration
+        .map(
+            cfg ->
+                cfg.isResourceManagerEnabled()
+                    || cfg.isResourcesEnabled()
+                    || Objects.nonNull(cfg.getDefaultStyle()))
+        .isPresent();
+  }
+}

--- a/ogcapi-custom/ogcapi-resources/src/main/java/de/ii/ogcapi/resources/app/StylesMigrationV4.java
+++ b/ogcapi-custom/ogcapi-resources/src/main/java/de/ii/ogcapi/resources/app/StylesMigrationV4.java
@@ -33,7 +33,7 @@ public class StylesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV
 
   @Override
   public String getSubject() {
-    return "building block Styles, properties 'resourcesEnables', 'resourceManagerEnabled', and 'defaultStyle'";
+    return "building block STYLES, properties 'resourcesEnables', 'resourceManagerEnabled', and 'defaultStyle'";
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/domain/StylesConfiguration.java
+++ b/ogcapi-draft/ogcapi-styles/src/main/java/de/ii/ogcapi/styles/domain/StylesConfiguration.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.styles.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Lists;
 import de.ii.ogcapi.foundation.domain.CachingConfiguration;
@@ -1531,6 +1532,7 @@ public interface StylesConfiguration extends ExtensionConfiguration, CachingConf
    */
   @Deprecated
   @Nullable
+  @JsonProperty(value = "resourcesEnabled", access = JsonProperty.Access.WRITE_ONLY)
   Boolean getResourcesEnabled();
 
   @Deprecated
@@ -1548,6 +1550,7 @@ public interface StylesConfiguration extends ExtensionConfiguration, CachingConf
    */
   @Deprecated
   @Nullable
+  @JsonProperty(value = "resourceManagerEnabled", access = JsonProperty.Access.WRITE_ONLY)
   Boolean getResourceManagerEnabled();
 
   @Deprecated
@@ -1565,6 +1568,7 @@ public interface StylesConfiguration extends ExtensionConfiguration, CachingConf
    */
   @Deprecated(since = "3.1.0")
   @Nullable
+  @JsonProperty(value = "defaultStyle", access = JsonProperty.Access.WRITE_ONLY)
   String getDefaultStyle();
 
   /**

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesHtmlConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesHtmlConfiguration.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.features.html.domain;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
@@ -157,6 +158,7 @@ public interface FeaturesHtmlConfiguration extends ExtensionConfiguration, Prope
    */
   @Deprecated(since = "3.1.0")
   @Nullable
+  @JsonProperty(value = "layout", access = JsonProperty.Access.WRITE_ONLY)
   LAYOUT getLayout();
 
   /**

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetMultiCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/api/AbstractEndpointTileSetMultiCollection.java
@@ -26,6 +26,7 @@ import de.ii.ogcapi.tiles.app.TilesBuildingBlock;
 import de.ii.ogcapi.tiles.domain.ImmutableQueryInputTileSet.Builder;
 import de.ii.ogcapi.tiles.domain.TileSetFormatExtension;
 import de.ii.ogcapi.tiles.domain.TilesConfiguration;
+import de.ii.ogcapi.tiles.domain.TilesProviders;
 import de.ii.ogcapi.tiles.domain.TilesQueriesHandler;
 import java.util.List;
 import java.util.Optional;
@@ -34,11 +35,15 @@ import javax.ws.rs.core.Response;
 public abstract class AbstractEndpointTileSetMultiCollection extends Endpoint {
 
   private final TilesQueriesHandler queryHandler;
+  protected final TilesProviders tilesProviders;
 
   public AbstractEndpointTileSetMultiCollection(
-      ExtensionRegistry extensionRegistry, TilesQueriesHandler queryHandler) {
+      ExtensionRegistry extensionRegistry,
+      TilesQueriesHandler queryHandler,
+      TilesProviders tilesProviders) {
     super(extensionRegistry);
     this.queryHandler = queryHandler;
+    this.tilesProviders = tilesProviders;
   }
 
   @Override
@@ -54,7 +59,7 @@ public abstract class AbstractEndpointTileSetMultiCollection extends Endpoint {
     return apiData
         .getExtension(TilesConfiguration.class)
         .filter(TilesConfiguration::isEnabled)
-        .filter(cfg -> cfg.hasDatasetTiles(null, apiData))
+        .filter(cfg -> cfg.hasDatasetTiles(tilesProviders, apiData))
         .isPresent();
   }
 

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesConfiguration.java
@@ -574,8 +574,7 @@ public interface TilesConfiguration extends SfFlatConfiguration, CachingConfigur
                           Objects.requireNonNullElse(getTileProviderTileset(), collectionId)))
           .orElse(false);
     }
-    return Objects.equals(getCollectionTiles(), true)
-        || (Objects.nonNull(getTileProvider()) && getTileProvider().isSingleCollectionEnabled());
+    return false;
   }
 
   /**
@@ -615,8 +614,7 @@ public interface TilesConfiguration extends SfFlatConfiguration, CachingConfigur
                           Objects.requireNonNullElse(getTileProviderTileset(), DATASET_TILES)))
           .orElse(false);
     }
-    return Objects.equals(getDatasetTiles(), true)
-        || (Objects.nonNull(getTileProvider()) && getTileProvider().isMultiCollectionEnabled());
+    return false;
   }
 
   /**

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesMigrationV4.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/TilesMigrationV4.java
@@ -135,6 +135,8 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
             .filters(Map.of())
             .rules(Map.of())
             .minimumSizeInPixel(null)
+            .datasetTiles(null)
+            .collectionTiles(null)
             .build();
 
     return new ImmutableOgcApiDataV2.Builder()
@@ -199,7 +201,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                   return collectionData
                       .getExtension(TilesConfiguration.class)
                       .filter(TilesConfiguration::isEnabled)
-                      .filter(cfg -> cfg.hasCollectionTiles(null, apiData, collectionData.getId()))
+                      .filter(cfg -> hasCollectionTiles(cfg))
                       .isPresent();
                 })
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -248,7 +250,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                 .putAllLevels(tilesConfiguration.getZoomLevelsDerived())
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles(null, null)
+            hasDatasetTiles(tilesConfiguration)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetMbTiles.Builder()
@@ -312,7 +314,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                             ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles(null, null)
+            hasDatasetTiles(tilesConfiguration)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetHttp.Builder()
@@ -397,7 +399,7 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                         : Optional.empty())
                 .build())
         .putAllTilesets(
-            tilesConfiguration.hasDatasetTiles(null, null)
+            hasDatasetTiles(tilesConfiguration)
                 ? Map.of(
                     TilesBuildingBlock.DATASET_TILES,
                     new ImmutableTilesetFeatures.Builder()
@@ -519,5 +521,17 @@ public class TilesMigrationV4 extends EntityMigration<OgcApiDataV2, OgcApiDataV2
                     LonLat.of(cfg.getCenterDerived().get(0), cfg.getCenterDerived().get(1)))
                 : Optional.empty())
         .build();
+  }
+
+  private static boolean hasDatasetTiles(TilesConfiguration tilesConfigurationOld) {
+    return Objects.equals(tilesConfigurationOld.getDatasetTiles(), true)
+        || (Objects.nonNull(tilesConfigurationOld.getTileProvider())
+            && tilesConfigurationOld.getTileProvider().isMultiCollectionEnabled());
+  }
+
+  private static boolean hasCollectionTiles(TilesConfiguration tilesConfigurationOld) {
+    return Objects.equals(tilesConfigurationOld.getCollectionTiles(), true)
+        || (Objects.nonNull(tilesConfigurationOld.getTileProvider())
+            && tilesConfigurationOld.getTileProvider().isSingleCollectionEnabled());
   }
 }

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileSetMultiCollection.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/infra/EndpointTileSetMultiCollection.java
@@ -45,15 +45,12 @@ public class EndpointTileSetMultiCollection extends AbstractEndpointTileSetMulti
 
   private static final List<String> TAGS = ImmutableList.of("Access multi-layer tiles");
 
-  private final TilesProviders tilesProviders;
-
   @Inject
   EndpointTileSetMultiCollection(
       ExtensionRegistry extensionRegistry,
       TilesQueriesHandler queryHandler,
       TilesProviders tilesProviders) {
-    super(extensionRegistry, queryHandler);
-    this.tilesProviders = tilesProviders;
+    super(extensionRegistry, queryHandler, tilesProviders);
   }
 
   @Override


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Properly migrate the following deprecated configuration properties for v4:

- TilesConfiguration.getCollectionTiles
- TilesConfiguration.getDatasetTiles
- StylesConfiguration.getResourcesEnabled
- StylesConfiguration.getResourceManagerEnabled
- StylesConfiguration.getDefaultStyle

@azahnen - please check