### PR TITLE
URIs are encoded in UTF-8

### DIFF
--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
@@ -336,7 +336,7 @@ public abstract class FeaturesView extends OgcApiDatasetView {
       List<String> ignore = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(without);
 
       List<NameValuePair> query =
-          URLEncodedUtils.parse(RawQuery().substring(1), StandardCharsets.ISO_8859_1).stream()
+          URLEncodedUtils.parse(RawQuery().substring(1), StandardCharsets.UTF_8).stream()
               .filter(kvp -> !ignore.contains(kvp.getName().toLowerCase()))
               .collect(Collectors.toList());
 


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

It is unclear why ISO 8859-1 is currently expected, but the current Apache HTTP Client uses UTF-8 as the default encoding. This may have been different in previous versions.

Closes #1120
