### PR TITLE
CQL2: update to release candidate

### DIFF
--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilter.java
@@ -119,7 +119,7 @@ public class QueryParameterFilter extends ApiExtensionCache
   @Override
   public String getDescription() {
     return "Filter features in the collection using the query expression in the parameter value. Filter expressions "
-        + "are written in the [Common Query Language (CQL2)](https://docs.ogc.org/DRAFTS/21-065.html), "
+        + "are written in the [Common Query Language (CQL2)](https://docs.ogc.org/DRAFTS/21-065r1.html), "
         + "which is a candidate OGC standard. This API implements the draft version from May 2022.\n\n"
         + "The recommended language for this query parameter is CQL2 Text (`filter-lang=cql2-text`).\n\n"
         + "CQL2 Text expressions are similar to SQL expressions and also support spatial, temporal and array predicates. "

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterLang.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterLang.java
@@ -87,7 +87,7 @@ public class QueryParameterFilterLang extends ApiExtensionCache
   @Override
   public String getDescription() {
     return "Language of the query expression in the 'filter' parameter. Supported are 'cql2-text' (default) and 'cql2-json', "
-        + "specified in the [candidate OGC standard 'Common Query Language (CQL2)'](https://docs.ogc.org/DRAFTS/21-065.html). "
+        + "specified in the [candidate OGC standard 'Common Query Language (CQL2)'](https://docs.ogc.org/DRAFTS/21-065r1.html). "
         + "'cql2-text' is an SQL-like text encoding for "
         + "filter expressions that also supports spatial, temporal and array predicates. 'cql2-json' is a JSON encoding of "
         + "that grammar, suitable for use as part of a JSON object that represents a query. The use of 'cql2-text' is recommended "

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
@@ -46,7 +46,7 @@ import javax.inject.Singleton;
  *     Language](https://docs.ogc.org/DRAFTS/19-079r2.html) as well as the conformance classes
  *     *Basic CQL2*, *Advanced Comparison Operators*, *Case-insensitive Comparisons*,
  *     *Accent-insensitive Comparisons*, *Basic Spatial Functions*, *Basic Spatial Functions with
- *     additional Spatial Data Types*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
+ *     additional Spatial Literals*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
  *     *Property-Property Comparisons*, *CQL2 Text encoding*, and *CQL2 JSON encoding* from the
  *     draft specification [Common Query Language (CQL2](https://docs.ogc.org/DRAFTS/21-065r1.html).
  *     The implementation is subject to change in the course of the development and approval process
@@ -59,7 +59,7 @@ import javax.inject.Singleton;
  *     Query Language](https://docs.ogc.org/DRAFTS/19-079r2.html) sowie die Konformitätsklassen
  *     *Basic CQL2*, *Advanced Comparison Operators*, *Case-insensitive Comparisons*,
  *     *Accent-insensitive Comparisons*, *Basic Spatial Functions*, *Basic Spatial Functions with
- *     additional Spatial Data Types*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
+ *     additional Spatial Literals*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
  *     *Property-Property Comparisons*, *CQL2 Text encoding*, und *CQL2 JSON encoding* aus dem
  *     Entwurf der Spezifikation [Common Query Language
  *     (CQL2](https://docs.ogc.org/DRAFTS/21-065r1.html). Die Implementierung wird sich im Zuge der

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
@@ -22,39 +22,67 @@ import javax.inject.Singleton;
  * @langEn Filter features with CQL2 expressions.
  * @langDe Features mit CQL2-Ausdrücken filtern.
  * @scopeEn This module provides query parameters to filter features using CQL2 (in Text or JSON
- *     encoding). Depending on the feature provider, some capabilities of CQL2 may not be supported.
- *     Specifically, in GeoPackage feature providers, queryables in a JSON column that are arrays
- *     are not supported. In PostgreSQL/PostGIS feature providers, the `A_OVERLAPS` operator is not
- *     supported for queryables in a JSON column.
+ *     encoding).
+ *     <p>In addition to the standard functions specified in CQL2, the following custom functions
+ *     are supported, too: <code>
+ * - `UPPER(String): String` returns the string in upper case.
+ * - `LOWER(String): String` returns the string in lower case.
+ * - `NOW(): Timestamp` returns the current time.
+ * - `DIAMETER2D(Geometry): Double` returns the diameter of a geometry with 2D coordinates.
+ * - `DIAMETER3D(Geometry): Double` returns the diameter of a geometry with 3D coordinates.
+ *     </code>
  * @scopeDe Dieses Modul bietet Abfrageparameter zum Filtern von Features mit CQL2 (in Text- oder
- *     JSON-Kodierung). Je nach Feature-Provider werden einige Funktionen von CQL2 möglicherweise
- *     nicht unterstützt. Insbesondere werden in GeoPackage Feature-Providern Queryables in einer
- *     JSON-Spalte, die Arrays sind, nicht unterstützt. In PostgreSQL/PostGIS-Feature-Anbietern wird
- *     der Operator `A_OVERLAPS` für Queryables in einer JSON-Spalte nicht unterstützt.
+ *     JSON-Kodierung).
+ *     <p>Zusätzlich zu den in CQL2 spezifizierten Standardfunktionen werden auch die folgenden
+ *     benutzerdefinierten Funktionen unterstützt: <code>
+ * - `UPPER(String): String` gibt die Zeichenkette in Großbuchstaben zurück.
+ * - `LOWER(String): String` gibt die Zeichenkette in Kleinbuchstaben zurück.
+ * - `NOW(): Timestamp` gibt die aktuelle Zeit zurück.
+ * - `DIAMETER2D(Geometry): Double` gibt den Durchmesser einer Geometrie mit 2D-Koordinaten zurück.
+ * - `DIAMETER3D(Geometry): Double` gibt den Durchmesser einer Geometrie mit 3D-Koordinaten zurück.
+ *     </code>
  * @conformanceEn This module implements requirements of the conformance classes *Filter* and
  *     *Features Filter* from the draft specification [OGC API - Features - Part 3: Common Query
- *     Language](https://docs.ogc.org/DRAFTS/19-079r1.html) as well as the conformance classes
+ *     Language](https://docs.ogc.org/DRAFTS/19-079r2.html) as well as the conformance classes
  *     *Basic CQL2*, *Advanced Comparison Operators*, *Case-insensitive Comparisons*,
- *     *Accent-insensitive Comparisons*, *Basic Spatial Operators*, *Spatial Operators*, *Temporal
- *     Operators*, *Array Operators*, *Property-Property Comparisons*, *CQL2 Text encoding*, and
- *     *CQL2 JSON encoding* from the draft specification [Common Query Language
- *     (CQL2](https://docs.ogc.org/DRAFTS/21-065.html). The implementation is subject to change in
- *     the course of the development and approval process of the draft.
+ *     *Accent-insensitive Comparisons*, *Basic Spatial Functions*, *Basic Spatial Functions with
+ *     additional Spatial Data Types*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
+ *     *Property-Property Comparisons*, *CQL2 Text encoding*, and *CQL2 JSON encoding* from the
+ *     draft specification [Common Query Language (CQL2](https://docs.ogc.org/DRAFTS/21-065r1.html).
+ *     The implementation is subject to change in the course of the development and approval process
+ *     of the draft.
  *     <p>The publication of queryables is controlled via [Feature Collections -
  *     Queryables](feature_collections_-_queryables.md) and is a prerequisite for clients to be able
  *     to determine the queryable feature properties.
  * @conformanceDe Dieses Modul implementiert die Anforderungen der Konformitätsklassen *Filter* und
  *     *Features Filter* aus dem Entwurf der Spezifikation [OGC API - Features - Part 3: Common
- *     Query Language](https://docs.ogc.org/DRAFTS/19-079r1.html) sowie die Konformitätsklassen
+ *     Query Language](https://docs.ogc.org/DRAFTS/19-079r2.html) sowie die Konformitätsklassen
  *     *Basic CQL2*, *Advanced Comparison Operators*, *Case-insensitive Comparisons*,
- *     *Accent-insensitive Comparisons*, *Basic Spatial Operators*, *Spatial Operators*, *Temporal
- *     Operators*, *Array Operators*, *Property-Property Comparisons*, *CQL2 Text encoding*, und
- *     *CQL2 JSON encoding* aus dem Entwurf der Spezifikation [Common Query Language
- *     (CQL2](https://docs.ogc.org/DRAFTS/21-065.html). Die Implementierung wird sich im Zuge der
+ *     *Accent-insensitive Comparisons*, *Basic Spatial Functions*, *Basic Spatial Functions with
+ *     additional Spatial Data Types*, *Spatial Functions*, *Temporal Functions*, *Array Functions*,
+ *     *Property-Property Comparisons*, *CQL2 Text encoding*, und *CQL2 JSON encoding* aus dem
+ *     Entwurf der Spezifikation [Common Query Language
+ *     (CQL2](https://docs.ogc.org/DRAFTS/21-065r1.html). Die Implementierung wird sich im Zuge der
  *     weiteren Standardisierung der Spezifikation noch ändern.
  *     <p>Die Veröffentlichung der Queryables wird über [Feature Collections -
  *     Queryables](feature_collections_-_queryables.md) gesteuert und ist Voraussetzung, damit
  *     Clients die abfragbaren Objekteigenschaften bestimmen können.
+ * @limitationsEn Depending on the feature provider, some capabilities of CQL2 may not be supported.
+ *     Specifically, in GeoPackage feature providers, queryables in a JSON column that are arrays
+ *     are not supported. In PostgreSQL/PostGIS feature providers, the `A_OVERLAPS` operator is not
+ *     supported for queryables in a JSON column.
+ *     <p>The conformance classes *Functions* and *Arithmetic Expressions* are not supported.
+ *     <p>The operator `IN` requires a property on the left side and literals on the right side.
+ *     <p>Only `booleanLiteral` may be used from `booleanExpression` in a `scalarExpression`.
+ * @limitationsDe Je nach Feature-Provider werden einige Funktionen von CQL2 möglicherweise nicht
+ *     unterstützt. Insbesondere werden in GeoPackage Feature-Providern Queryables in einer
+ *     JSON-Spalte, die Arrays sind, nicht unterstützt. In PostgreSQL/PostGIS-Feature-Anbietern wird
+ *     der Operator `A_OVERLAPS` für Queryables in einer JSON-Spalte nicht unterstützt.
+ *     <p>Die Konformitätsklassen *Functions* und *Arithmetic Expressions* werden nicht unterstützt.
+ *     <p>In einer `scalarExpression` darf aus `booleanExpression` nur `booleanLiteral` verwendet
+ *     werden.
+ *     <p>Der Operator `IN` erfordert eine Eigenschaft auf der linken Seite und Literale auf der
+ *     rechten Seite.
  * @ref:cfg {@link de.ii.ogcapi.filter.domain.FilterConfiguration}
  * @ref:cfgProperties {@link de.ii.ogcapi.filter.domain.ImmutableFilterConfiguration}
  * @ref:queryParameters {@link de.ii.ogcapi.filter.api.QueryParameterFilter}, {@link
@@ -70,7 +98,7 @@ public class FilterBuildingBlock implements ApiBuildingBlock {
   public static final Optional<ExternalDocumentation> SPEC =
       Optional.of(
           ExternalDocumentation.of(
-              "https://docs.ogc.org/DRAFTS/19-079r1.html",
+              "https://docs.ogc.org/DRAFTS/19-079r2.html",
               "OGC API - Features - Part 3: Filtering (DRAFT)"));
 
   @Inject

--- a/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/app/FilterBuildingBlock.java
@@ -74,6 +74,7 @@ import javax.inject.Singleton;
  *     <p>The conformance classes *Functions* and *Arithmetic Expressions* are not supported.
  *     <p>The operator `IN` requires a property on the left side and literals on the right side.
  *     <p>Only `booleanLiteral` may be used from `booleanExpression` in a `scalarExpression`.
+ *     <p>The Unicode characters "\x10000" to "\x10FFFF" are not supported.
  * @limitationsDe Je nach Feature-Provider werden einige Funktionen von CQL2 möglicherweise nicht
  *     unterstützt. Insbesondere werden in GeoPackage Feature-Providern Queryables in einer
  *     JSON-Spalte, die Arrays sind, nicht unterstützt. In PostgreSQL/PostGIS-Feature-Anbietern wird
@@ -83,6 +84,7 @@ import javax.inject.Singleton;
  *     werden.
  *     <p>Der Operator `IN` erfordert eine Eigenschaft auf der linken Seite und Literale auf der
  *     rechten Seite.
+ *     <p>Die Unicode-Zeichen "\x10000" bis "\x10FFFF" werden nicht unterstützt.
  * @ref:cfg {@link de.ii.ogcapi.filter.domain.FilterConfiguration}
  * @ref:cfgProperties {@link de.ii.ogcapi.filter.domain.ImmutableFilterConfiguration}
  * @ref:queryParameters {@link de.ii.ogcapi.filter.api.QueryParameterFilter}, {@link

--- a/ogcapi-draft/ogcapi-filter/src/test/groovy/de/ii/ogcapi/filter/FilterParameterSpecification.groovy
+++ b/ogcapi-draft/ogcapi-filter/src/test/groovy/de/ii/ogcapi/filter/FilterParameterSpecification.groovy
@@ -65,7 +65,7 @@ class FilterParameterSpecification extends Specification {
     @Shared
     def collection = getRequest(restClient, API_PATH_DARAA + "/collections/" + AERONAUTIC_CRV, null)
     @Shared
-    def envelopeCollection = "ENVELOPE(" + String.join(",", collection.responseData.extent.spatial.bbox[0].stream().map(n -> String.valueOf(n)).toList()) + ")"
+    def envelopeCollection = "BBOX(" + String.join(",", collection.responseData.extent.spatial.bbox[0].stream().map(n -> String.valueOf(n)).toList()) + ")"
     @Shared
     def idPnt = allCulturePntFeatures.responseData.features[0].id
     @Shared
@@ -81,7 +81,7 @@ class FilterParameterSpecification extends Specification {
     @Shared
     def delta = 0.02
     @Shared
-    def envelopeCrv = "ENVELOPE(" + String.join(",", String.valueOf(lonCrv-delta), String.valueOf(latCrv-delta), String.valueOf(lonCrv+delta), String.valueOf(latCrv+delta)) + ")"
+    def envelopeCrv = "BBOX(" + String.join(",", String.valueOf(lonCrv-delta), String.valueOf(latCrv-delta), String.valueOf(lonCrv+delta), String.valueOf(latCrv+delta)) + ")"
     @Shared
     def polygonCrv = "POLYGON((" + String.join(",",
             String.valueOf(lonCrv-delta)+" "+String.valueOf(latCrv),
@@ -96,7 +96,7 @@ class FilterParameterSpecification extends Specification {
     @Shared
     def epsg4326 = "http://www.opengis.net/def/crs/EPSG/0/4326"
     @Shared
-    def envelopeCrv4326 = "ENVELOPE(" + String.join(",", String.valueOf(latCrv-delta), String.valueOf(lonCrv-delta), String.valueOf(latCrv+delta), String.valueOf(lonCrv+delta)) + ")"
+    def envelopeCrv4326 = "BBOX(" + String.join(",", String.valueOf(latCrv-delta), String.valueOf(lonCrv-delta), String.valueOf(latCrv+delta), String.valueOf(lonCrv+delta)) + ")"
     @Shared
     def polygonCrv4326 = "POLYGON((" + String.join(",",
             String.valueOf(latCrv)+" "+String.valueOf(lonCrv-delta),

--- a/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/Subtree.java
+++ b/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/Subtree.java
@@ -32,7 +32,7 @@ import de.ii.ogcapi.foundation.domain.QueryParameterSet;
 import de.ii.ogcapi.tiles3d.domain.QueriesHandler3dTiles.QueryInputSubtree;
 import de.ii.xtraplatform.cql.domain.And;
 import de.ii.xtraplatform.cql.domain.Cql2Expression;
-import de.ii.xtraplatform.cql.domain.Geometry.Envelope;
+import de.ii.xtraplatform.cql.domain.Geometry.Bbox;
 import de.ii.xtraplatform.cql.domain.Property;
 import de.ii.xtraplatform.cql.domain.SIntersects;
 import de.ii.xtraplatform.cql.domain.SpatialLiteral;
@@ -454,12 +454,11 @@ public interface Subtree {
       QueryInputSubtree queryInput,
       BoundingBox bbox,
       Optional<Cql2Expression> additionalFilter) {
-    Envelope envelope =
-        Envelope.of(
-            bbox.getXmin(), bbox.getYmin(), bbox.getXmax(), bbox.getYmax(), bbox.getEpsgCrs());
+    Bbox bbox2 =
+        Bbox.of(bbox.getXmin(), bbox.getYmin(), bbox.getXmax(), bbox.getYmax(), bbox.getEpsgCrs());
 
     Cql2Expression filter =
-        SIntersects.of(Property.of(queryInput.getGeometryProperty()), SpatialLiteral.of(envelope));
+        SIntersects.of(Property.of(queryInput.getGeometryProperty()), SpatialLiteral.of(bbox2));
 
     if (additionalFilter.isPresent()) {
       filter = And.of(filter, additionalFilter.get());

--- a/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/TileResourceDescriptor.java
+++ b/ogcapi-draft/ogcapi-tiles3d/src/main/java/de/ii/ogcapi/tiles3d/domain/TileResourceDescriptor.java
@@ -15,7 +15,7 @@ import de.ii.ogcapi.foundation.domain.OgcApi;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.xtraplatform.cql.domain.BooleanValue2;
 import de.ii.xtraplatform.cql.domain.Cql2Expression;
-import de.ii.xtraplatform.cql.domain.Geometry.Envelope;
+import de.ii.xtraplatform.cql.domain.Geometry.Bbox;
 import de.ii.xtraplatform.cql.domain.Property;
 import de.ii.xtraplatform.cql.domain.SIntersects;
 import de.ii.xtraplatform.cql.domain.SpatialLiteral;
@@ -131,7 +131,7 @@ public abstract class TileResourceDescriptor {
                         (Cql2Expression)
                             SIntersects.of(
                                 Property.of(property.getFullPathAsString()),
-                                SpatialLiteral.of(Envelope.of(computeBbox()))))
+                                SpatialLiteral.of(Bbox.of(computeBbox()))))
                 .orElse(BooleanValue2.of(false)))
         .build();
   }

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryablesBuildingBlock.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryablesBuildingBlock.java
@@ -67,10 +67,10 @@ import javax.inject.Singleton;
  *     einem Array verschachtelt ist, ist der Typ der abfragbaren Eigenschaft ein Array der Werte.
  * @conformanceEn *Feature Collections - Queryables* implements all requirements and recommendations
  *     of chapter 6 ("Queryables") of the [draft OGC API - Features - Part 3:
- *     Filtering](https://docs.ogc.org/DRAFTS/19-079r1.html#queryables).
+ *     Filtering](https://docs.ogc.org/DRAFTS/19-079r2.html#queryables).
  * @conformanceDe Das Modul implementiert die Vorgaben und Empfehlungen aus Kapitel 6 ("Queryables")
  *     des [Entwurfs von OGC API - Features - Part 3:
- *     Filtering](https://docs.ogc.org/DRAFTS/19-079r1.html#queryables).
+ *     Filtering](https://docs.ogc.org/DRAFTS/19-079r2.html#queryables).
  * @limitationsEn The draft of OGC API - Features - Part 3 does not specify how a queryable that is
  *     a feature reference which has more variables than the local feature id should be handled. If
  *     such a property is a queryable, the current implementation uses the local feature id as the
@@ -101,7 +101,7 @@ public class QueryablesBuildingBlock implements ApiBuildingBlock {
   public static final Optional<ExternalDocumentation> SPEC =
       Optional.of(
           ExternalDocumentation.of(
-              "https://docs.ogc.org/DRAFTS/19-079r1.html",
+              "https://docs.ogc.org/DRAFTS/19-079r2.html",
               "OGC API - Features - Part 3: Filtering (DRAFT)"));
 
   private final SchemaInfo schemaInfo;

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,5 +2,5 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.4.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-cql2-update-SNAPSHOT'
 }

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -2,5 +2,5 @@
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.4.0-${platform}-SNAPSHOT"
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-cql2-update-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-SNAPSHOT'
 }


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #599. If there are any additional changes in the approval process, we will create a new issue and PR.

Depends on https://github.com/interactive-instruments/xtraplatform-spatial/pull/268.

ANTLR does not support the range `\u10000` to `\u10FFFF`, at least this is what is reported as an error, if a one of those characters is included in the lexer. According to the [documentation](https://github.com/antlr/antlr4/blob/dev/doc/unicode.md), the currently used version of ANTLR should support these characters, but this does not seem to be the case. In practice, this was no issue so far.
