### PR TITLE
change services endpoint path to root

### DIFF
--- a/demo/vineyards/README.md
+++ b/demo/vineyards/README.md
@@ -142,7 +142,7 @@ INFO  [2021-12-18 07:29:39,089]                vineyards - Feature provider with
 INFO  [2021-12-18 07:29:39,400]                vineyards - Service with id 'vineyards' started successfully.  
 ```
 
-Congratulations, you are now ready to use the API, just open the [landing page](http://localhost:7080/rest/services/vineyards) or the [vineyards features](http://localhost:7080/rest/services/vineyards/collections/vineyards/items).
+Congratulations, you are now ready to use the API, just open the [landing page](http://localhost:7080/vineyards) or the [vineyards features](http://localhost:7080/vineyards/collections/vineyards/items).
 
 Have a look at the updated configuration files. They should like the following, first the providers file, the the services file.
 

--- a/ogcapi-draft/ogcapi-crud/src/test/groovy/de/ii/ogcapi/crud/TransactionalRESTApiSpec.groovy
+++ b/ogcapi-draft/ogcapi-crud/src/test/groovy/de/ii/ogcapi/crud/TransactionalRESTApiSpec.groovy
@@ -16,7 +16,7 @@ import spock.lang.Specification
 class TransactionalRESTApiSpec extends Specification{
 
     static String SUT_URL = System.getenv('SUT_URL')
-    static String SUT_PATH = "/rest/services/daraa"
+    static String SUT_PATH = "/daraa"
     static String SUT_COLLECTION = "aeronauticcrv"
     static String SUT_ID = "21"
 

--- a/ogcapi-draft/ogcapi-filter/build.gradle
+++ b/ogcapi-draft/ogcapi-filter/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 test {
     // activate to run filter tests
-    // environment "SUT_URL", "http://localhost:7080/rest/services"
+    // environment "SUT_URL", "http://localhost:7080"
     // environment "SUT_URL", "https://demo.ldproxy.net"
 }
 

--- a/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesManagerRESTApiSpec.groovy
+++ b/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesManagerRESTApiSpec.groovy
@@ -17,7 +17,7 @@ import spock.lang.Specification
 class StylesManagerRESTApiSpec extends Specification {
 
     static final String SUT_URL = System.getenv('SUT_URL')
-    static final String SUT_PATH = "/rest/services/daraa"
+    static final String SUT_PATH = "/daraa"
     static final String SUT_COLLECTION = "aeronauticcrv"
     static final String SUT_STYLE = "default"
 

--- a/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesRESTApiSpec.groovy
+++ b/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesRESTApiSpec.groovy
@@ -15,7 +15,7 @@ import spock.lang.Specification
 class StylesRESTApiSpec extends Specification{
 
     static final String SUT_URL = System.getenv('SUT_URL')
-    static final String SUT_PATH = "/rest/services/daraa"
+    static final String SUT_PATH = "/daraa"
     static final String SUT_COLLECTION = "aeronauticcrv"
     static final String SUT_STYLE = "daraa"
 

--- a/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesRepresentationRESTApiSpec.groovy
+++ b/ogcapi-draft/ogcapi-styles/src/test/groovy/de/ii/ogcapi/styles/app/StylesRepresentationRESTApiSpec.groovy
@@ -16,7 +16,7 @@ import spock.lang.Specification
 class StylesRepresentationRESTApiSpec extends Specification {
 
     static final String SUT_URL = System.getenv('SUT_URL')
-    static final String SUT_PATH = "/rest/services/daraa"
+    static final String SUT_PATH = "/daraa"
     static final String SUT_STYLE = "topographic"
 
     RESTClient restClient = new RESTClient(SUT_URL)

--- a/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/OgcApiCoreRestApiSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/OgcApiCoreRestApiSpec.groovy
@@ -24,7 +24,7 @@ import  java.time.format.DateTimeFormatter
 class OgcApiCoreRestApiSpec extends Specification {
 
     static final String SUT_URL = System.getenv('SUT_URL')
-    static final String SUT_PATH = "/rest/services/daraa"
+    static final String SUT_PATH = "/daraa"
     static final String SUT_COLLECTION = "agriculturesrf"
     static final String SUT_COLLECTION2 = "culturesrf"
     static final String SUT_ID = "1"

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/AbstractRequestContext.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/AbstractRequestContext.java
@@ -45,7 +45,7 @@ public abstract class AbstractRequestContext implements ApiRequestContext {
     URICustomizer uriCustomizer = new URICustomizer(getRequestUri());
 
     uriCustomizer.setScheme(getExternalUri().getScheme());
-    uriCustomizer.replaceInPath("/rest/services", getExternalUri().getPath());
+    uriCustomizer.prependPathSegments(getExternalUriPath());
 
     return uriCustomizer;
   }
@@ -57,8 +57,7 @@ public abstract class AbstractRequestContext implements ApiRequestContext {
 
     staticUrlPrefix =
         new URICustomizer(getRequestUri())
-            .cutPathAfterSegments("rest", "services")
-            .replaceInPath("/rest/services", getExternalUri().getPath())
+            .setPathSegments(getExternalUriPath())
             .ensureLastPathSegment(STATIC_PATH)
             .ensureNoTrailingSlash()
             .getPath();

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiCatalogProvider.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiCatalogProvider.java
@@ -7,6 +7,9 @@
  */
 package de.ii.ogcapi.foundation.domain;
 
+import static de.ii.ogcapi.foundation.domain.AbstractRequestContext.STATIC_PATH;
+import static de.ii.ogcapi.foundation.domain.ApiRequestContext.PATH_SPLITTER;
+
 import com.google.common.base.Splitter;
 import de.ii.ogcapi.foundation.domain.ImmutableApiCatalog.Builder;
 import de.ii.xtraplatform.entities.domain.EntityDataBuilder;
@@ -61,30 +64,19 @@ public abstract class ApiCatalogProvider implements ServiceListingProvider, ApiE
 
   public abstract ApiMediaType getApiMediaType();
 
-  private Optional<URI> getExternalUri() {
-    return Optional.of(servicesUri);
-  }
-
   private void customizeUri(final URICustomizer uriCustomizer) {
-    if (getExternalUri().isPresent()) {
-      uriCustomizer.setScheme(getExternalUri().get().getScheme());
-      uriCustomizer.replaceInPath("/rest/services", getExternalUri().get().getPath());
-      uriCustomizer.ensureNoTrailingSlash();
-    }
+    uriCustomizer.setScheme(servicesUri.getScheme());
+    uriCustomizer.prependPathSegments(PATH_SPLITTER.splitToList(servicesUri.getPath()));
+    uriCustomizer.ensureNoTrailingSlash();
   }
 
   private String getStaticUrlPrefix(final URICustomizer uriCustomizer) {
-    if (getExternalUri().isPresent()) {
-      return uriCustomizer
-          .copy()
-          .cutPathAfterSegments("rest", "services")
-          .replaceInPath("/rest/services", getExternalUri().get().getPath())
-          .ensureLastPathSegment("___static___")
-          .ensureNoTrailingSlash()
-          .getPath();
-    }
-
-    return "";
+    return uriCustomizer
+        .copy()
+        .setPathSegments(PATH_SPLITTER.splitToList(servicesUri.getPath()))
+        .ensureLastPathSegment(STATIC_PATH)
+        .ensureNoTrailingSlash()
+        .getPath();
   }
 
   private FoundationConfiguration getFoundationConfigurationDefaults() {

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiRequestContext.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ApiRequestContext.java
@@ -7,6 +7,7 @@
  */
 package de.ii.ogcapi.foundation.domain;
 
+import com.google.common.base.Splitter;
 import de.ii.xtraplatform.auth.domain.User;
 import java.net.URI;
 import java.nio.file.Path;
@@ -19,6 +20,8 @@ import javax.ws.rs.core.Request;
 import org.immutables.value.Value;
 
 public interface ApiRequestContext {
+
+  Splitter PATH_SPLITTER = Splitter.on('/').trimResults().omitEmptyStrings();
 
   URI getExternalUri();
 
@@ -45,6 +48,11 @@ public interface ApiRequestContext {
   @Value.Default
   default int getMaxResponseLinkHeaderSize() {
     return 2048;
+  }
+
+  @Value.Derived
+  default List<String> getExternalUriPath() {
+    return PATH_SPLITTER.splitToList(getExternalUri().getPath());
   }
 
   @Value.Derived

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/URICustomizer.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/URICustomizer.java
@@ -58,6 +58,12 @@ public class URICustomizer extends URIBuilder {
     return this;
   }
 
+  @Override
+  public URICustomizer setPathSegments(List<String> pathSegments) {
+    super.setPathSegments(pathSegments);
+    return this;
+  }
+
   public URICustomizer ensureParameter(final String parameter, final String value) {
     if (this.getQueryParams().stream()
         .noneMatch(nameValuePair -> nameValuePair.getName().equals(parameter))) {
@@ -82,6 +88,19 @@ public class URICustomizer extends URIBuilder {
     final List<String> pathSegments = getPathSegments();
 
     return pathSegments.isEmpty() ? null : pathSegments.get(pathSegments.size() - 1);
+  }
+
+  public URICustomizer prependPathSegments(final String... segments) {
+    return prependPathSegments(List.of(segments));
+  }
+
+  public URICustomizer prependPathSegments(final Iterable<String> segments) {
+    final List<String> pathSegments = getPathSegments();
+
+    this.setPathSegments(
+        new ImmutableList.Builder<String>().addAll(segments).addAll(pathSegments).build());
+
+    return this;
   }
 
   public URICustomizer ensureLastPathSegment(final String segment) {

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/infra/rest/ExceptionMapper.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/infra/rest/ExceptionMapper.java
@@ -259,6 +259,6 @@ public class ExceptionMapper extends LoggingExceptionMapper<Throwable> {
   private String getRequestPath(@SuppressWarnings("SameParameterValue") boolean queryParameters) {
     String s =
         queryParameters ? uriInfo.getRequestUri().toString() : uriInfo.getAbsolutePath().toString();
-    return s.substring(s.lastIndexOf("/rest/services") + 14);
+    return s.substring(s.indexOf("/", s.indexOf("//") + 1));
   }
 }

--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/stories.jsx
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/stories.jsx
@@ -15,7 +15,7 @@ Plain.args = {
   styleUrl: "https://demo.ldproxy.net/daraa/styles/topographic-with-basemap?f=mbs",
   // styleUrl: "https://demo.ldproxy.net/strassen/styles/default?f=mbs",
   // styleUrl:
-  // "http://localhost:7080/rest/services/daraa/styles/topographic-with-basemap-layercontrol?f=mbs",
+  // "http://localhost:7080/daraa/styles/topographic-with-basemap-layercontrol?f=mbs",
   /* layerGroupControl: [
     {
       id: "Abschnitte und Äste",
@@ -183,7 +183,7 @@ export const Items = Template.bind({});
 
 Items.args = {
     dataUrl:
-    "http://localhost:7080/rest/services/feuerwehr/v1/collections/governmentalservice/items?f=json",
+    "http://localhost:7080/feuerwehr/v1/collections/governmentalservice/items?f=json",
 };
 
 export const Extent = Template.bind({});
@@ -204,10 +204,10 @@ export const Tiles = Template.bind({});
 
 Tiles.args = {
     dataUrl:
-    "http://localhost:7080/rest/services/feuerwehr/v1/tiles/WebMercatorQuad/{z}/{y}/{x}?f=mvt",
+    "http://localhost:7080/feuerwehr/v1/tiles/WebMercatorQuad/{z}/{y}/{x}?f=mvt",
   dataType: "vector",
   dataLayers: { governmentalservice: ["points"] },
     // styleUrl:
-    //    'http://localhost:7080/rest/services/feuerwehr/v1/styles/default?f=mbs',
+    //    'http://localhost:7080/feuerwehr/v1/styles/default?f=mbs',
   popup: "CLICK_PROPERTIES",
 }; */

--- a/ogcapi-stable/ogcapi-tiles/src/test/groovy/de/ii/ogcapi/tiles/TilesRESTApiSpec.groovy
+++ b/ogcapi-stable/ogcapi-tiles/src/test/groovy/de/ii/ogcapi/tiles/TilesRESTApiSpec.groovy
@@ -19,7 +19,7 @@ import spock.lang.Specification
 class TilesRESTApiSpec extends Specification{
 
     static final String SUT_URL = System.getenv('SUT_URL')
-    static final String SUT_PATH = "/rest/services/daraa"
+    static final String SUT_PATH = "/daraa"
     static final String SUT_TILE_MATRIX_SET_ID = "WebMercatorQuad"
     static final String SUT_COLLECTION = "aeronauticcrv"
     static final String SUT_COLLECTION2 = "aeronauticsrf"

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-root-path-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.4.0-${platform}-SNAPSHOT"
     layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-SNAPSHOT'
 }

--- a/xtraplatform.gradle
+++ b/xtraplatform.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-root-path-SNAPSHOT'
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '6.0.0-SNAPSHOT'
     layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.4.0-${platform}-SNAPSHOT"
     layers group: 'de.interactive_instruments', name: 'xtraplatform-spatial', version: '7.0.0-SNAPSHOT'
 }


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on a PR over several days, please create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly (feel free to ask for help):
-->

### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

<!--
    Either reference the issue(s) that describe the changes introduced by this PR 
-->

Closes #1190 .

<!--
    or shortly describe the changes below using bullet points
-->

Depends on interactive-instruments/xtraplatform#160.

Traefik can be used to test that using a reverse proxy to change the path still works as expected:

```yml
version: "3.3"

services:

  traefik:
    image: "traefik:v2.11"
    command:
      - "--providers.docker=true"
      - "--entrypoints.web.address=:7080"
    ports:
      - "7080:7080"
    volumes:
      - "/var/run/docker.sock:/var/run/docker.sock:ro"

  ldproxy:
    image: "docker.ci.interactive-instruments.de/iide/ldproxy:root-path"
    environment:
      - EXTERNAL_URL="http://localhost:7080/foo/bar" 
      - DB_HOST=host.docker.internal:5432
    volumes:
      - /path/to/configs-ldproxy/xleit:/ldproxy/data
    labels:
      - traefik.http.services.ldp.loadbalancer.server.port=7080
      - traefik.http.routers.ldp.rule=Host(`localhost`) && PathPrefix(`/foo/bar`)
      - traefik.http.routers.ldp.entrypoints=web
      - traefik.http.middlewares.prefix.stripprefix.prefixes=/foo/bar
      - traefik.http.routers.ldp.middlewares=prefix
```
