### PR TITLE
maintain CRS dimension in cached spatial extents

### DIFF
--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ChangingSpatialExtent.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ChangingSpatialExtent.java
@@ -41,11 +41,20 @@ public interface ChangingSpatialExtent extends ChangingValue<BoundingBox> {
 
     return Optional.of(
         ChangingSpatialExtent.of(
-            BoundingBox.of(
-                Math.min(getValue().getXmin(), deltaExtent.getXmin()),
-                Math.min(getValue().getYmin(), deltaExtent.getYmin()),
-                Math.max(getValue().getXmax(), deltaExtent.getXmax()),
-                Math.max(getValue().getYmax(), deltaExtent.getYmax()),
-                OgcCrs.CRS84)));
+            deltaExtent.getEpsgCrs().equals(OgcCrs.CRS84)
+                ? BoundingBox.of(
+                    Math.min(getValue().getXmin(), deltaExtent.getXmin()),
+                    Math.min(getValue().getYmin(), deltaExtent.getYmin()),
+                    Math.max(getValue().getXmax(), deltaExtent.getXmax()),
+                    Math.max(getValue().getYmax(), deltaExtent.getYmax()),
+                    OgcCrs.CRS84)
+                : BoundingBox.of(
+                    Math.min(getValue().getXmin(), deltaExtent.getXmin()),
+                    Math.min(getValue().getYmin(), deltaExtent.getYmin()),
+                    Math.min(getValue().getZmin(), deltaExtent.getZmin()),
+                    Math.max(getValue().getXmax(), deltaExtent.getXmax()),
+                    Math.max(getValue().getYmax(), deltaExtent.getYmax()),
+                    Math.max(getValue().getZmax(), deltaExtent.getZmax()),
+                    OgcCrs.CRS84h)));
   }
 }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

If a changing spatial extent is updated, it is stored as a CRS84 extent. If the data is 3D, the extent must be a CRS84h extent, otherwise the next update will fail, because the delta extent is in CRS84h, but the cached extent is in CRS84.