### PR TITLE
additional metadata in the WMTS ServiceProvider

### DIFF
--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsAddress.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsAddress.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.tiles.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.google.common.hash.Funnel;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(deepImmutablesDetection = true)
+@JsonPropertyOrder({"electronicMailAddress"})
+public interface OwsAddress {
+
+  @JacksonXmlProperty(
+      namespace = WmtsServiceMetadata.XMLNS_OWS,
+      localName = "ElectronicMailAddress")
+  Optional<String> getElectronicMailAddress();
+
+  @SuppressWarnings("UnstableApiUsage")
+  Funnel<OwsAddress> FUNNEL =
+      (from, into) -> {
+        from.getElectronicMailAddress()
+            .ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+      };
+}

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsContact.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsContact.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.tiles.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.google.common.hash.Funnel;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(deepImmutablesDetection = true)
+@JsonPropertyOrder({"phone", "address", "onlineResource"})
+public interface OwsContact {
+
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "Phone")
+  Optional<OwsTelephone> getPhone();
+
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "Address")
+  Optional<OwsAddress> getAddress();
+
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "OnlineResource")
+  Optional<OwsOnlineResource> getOnlineResource();
+
+  @SuppressWarnings("UnstableApiUsage")
+  Funnel<OwsContact> FUNNEL =
+      (from, into) -> {
+        from.getPhone().ifPresent(val -> OwsTelephone.FUNNEL.funnel(val, into));
+        from.getAddress().ifPresent(val -> OwsAddress.FUNNEL.funnel(val, into));
+        from.getOnlineResource().ifPresent(val -> OwsOnlineResource.FUNNEL.funnel(val, into));
+      };
+}

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsResponsibleParty.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsResponsibleParty.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.tiles.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.google.common.hash.Funnel;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(deepImmutablesDetection = true)
+@JsonPropertyOrder({"individualName", "positionName", "role", "contactInfo"})
+public interface OwsResponsibleParty {
+
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "IndividualName")
+  Optional<String> getIndividualName();
+
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "ContactInfo")
+  Optional<OwsContact> getContactInfo();
+
+  @SuppressWarnings("UnstableApiUsage")
+  Funnel<OwsResponsibleParty> FUNNEL =
+      (from, into) -> {
+        from.getIndividualName().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getContactInfo().ifPresent(val -> OwsContact.FUNNEL.funnel(val, into));
+      };
+}

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsServiceProvider.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsServiceProvider.java
@@ -26,7 +26,7 @@ public interface OwsServiceProvider {
   Optional<OwsOnlineResource> getProviderSite();
 
   @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "ServiceContact")
-  OwsServiceContact getServiceContact();
+  OwsResponsibleParty getServiceContact();
 
   @SuppressWarnings("UnstableApiUsage")
   Funnel<OwsServiceProvider> FUNNEL =

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsTelephone.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/domain/OwsTelephone.java
@@ -16,17 +16,15 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(deepImmutablesDetection = true)
-@JsonPropertyOrder({"individualName"})
-public interface OwsServiceContact {
+@JsonPropertyOrder({"voice"})
+public interface OwsTelephone {
 
-  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "IndividualName")
-  Optional<String> getIndividualName();
-
-  // TODO add more from OWS Common?
+  @JacksonXmlProperty(namespace = WmtsServiceMetadata.XMLNS_OWS, localName = "Voice")
+  Optional<String> getVoice();
 
   @SuppressWarnings("UnstableApiUsage")
-  Funnel<OwsServiceContact> FUNNEL =
+  Funnel<OwsTelephone> FUNNEL =
       (from, into) -> {
-        from.getIndividualName().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
+        from.getVoice().ifPresent(val -> into.putString(val, StandardCharsets.UTF_8));
       };
 }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

The WMTS Capabilities contained only minimal Service Provider information in the Capabilities document (provider name and site). This pull request adds additional elements where that data is available for the API: contact name, email and telephone.