### PR TITLE
fix temporal extent on landing page

### DIFF
--- a/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/infra/EndpointCollection.java
+++ b/ogcapi-stable/ogcapi-collections/src/main/java/de/ii/ogcapi/collections/infra/EndpointCollection.java
@@ -173,13 +173,10 @@ public class EndpointCollection extends EndpointSubCollection {
         }
         Optional<TemporalExtent> temporal = extent.get().getTemporal();
         if (temporal.isPresent() && Objects.nonNull(temporal.get())) {
-          long start =
-              Objects.nonNull(temporal.get().getStart())
-                  ? temporal.get().getStart()
-                  : Long.MIN_VALUE;
-          long end =
-              Objects.nonNull(temporal.get().getEnd()) ? temporal.get().getEnd() : Long.MAX_VALUE;
-          if (end < start) {
+          Long start =
+              Objects.nonNull(temporal.get().getStart()) ? temporal.get().getStart() : null;
+          Long end = Objects.nonNull(temporal.get().getEnd()) ? temporal.get().getEnd() : null;
+          if (start != null && end != null && end < start) {
             builder.addStrictErrors(
                 MessageFormat.format(
                     "The temporal extent in collection ''{0}'' has an end ''{1}'' before the start ''{2}''.",

--- a/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/OgcApiCoreSpecCollections.groovy
+++ b/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/OgcApiCoreSpecCollections.groovy
@@ -332,7 +332,7 @@ class OgcApiCoreSpecCollections extends Specification {
     static def createOgcApiApiEntity(ExtensionRegistry registry, OgcApiDataV2 datasetData) {
         def entity = new OgcApiEntity(null, registry, () -> "", new AppContextTest(), null, new CacheTest(), datasetData)
         entity.updateSpatialExtent("featureType1", BoundingBox.of(-180, -90, 180, 90, OgcCrs.CRS84))
-        entity.updateTemporalExtent("featureType1", TemporalExtent.of(Long.MIN_VALUE, Long.MAX_VALUE))
+        entity.updateTemporalExtent("featureType1", TemporalExtent.of(null, null))
         entity.updateItemCount("featureType1", 0)
         return entity
     }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ChangingTemporalExtent.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ChangingTemporalExtent.java
@@ -17,25 +17,31 @@ public interface ChangingTemporalExtent extends ChangingValue<TemporalExtent> {
 
   static ChangingTemporalExtent of(TemporalExtent interval) {
     return new ImmutableChangingTemporalExtent.Builder()
-        .value(
-            Objects.requireNonNullElse(interval, TemporalExtent.of(Long.MIN_VALUE, Long.MAX_VALUE)))
+        .value(Objects.requireNonNullElse(interval, TemporalExtent.of(null, null)))
         .build();
   }
 
   @Override
   default Optional<ChangingValue<TemporalExtent>> updateWith(ChangingValue<TemporalExtent> delta) {
     TemporalExtent deltaExtent = delta.getValue();
-    long currentStart = Objects.requireNonNullElse(getValue().getStart(), Long.MIN_VALUE);
-    long currentEnd = Objects.requireNonNullElse(getValue().getEnd(), Long.MAX_VALUE);
-    long deltaStart = Objects.requireNonNullElse(deltaExtent.getStart(), Long.MIN_VALUE);
-    long deltaEnd = Objects.requireNonNullElse(deltaExtent.getEnd(), Long.MAX_VALUE);
+    Long currentStart = getValue().getStart();
+    Long currentEnd = getValue().getEnd();
+    Long deltaStart = deltaExtent.getStart();
+    Long deltaEnd = deltaExtent.getEnd();
 
-    if (currentStart <= deltaStart && currentEnd >= deltaEnd) {
+    if (Objects.requireNonNullElse(currentStart, Long.MIN_VALUE)
+            <= Objects.requireNonNullElse(deltaStart, Long.MIN_VALUE)
+        && Objects.requireNonNullElse(currentEnd, Long.MAX_VALUE)
+            >= Objects.requireNonNullElse(deltaEnd, Long.MAX_VALUE)) {
       return Optional.empty();
     }
 
     return Optional.of(
         ChangingTemporalExtent.of(
-            TemporalExtent.of(Math.min(currentStart, deltaStart), Math.max(currentEnd, deltaEnd))));
+            TemporalExtent.of(
+                currentStart == null || deltaStart == null
+                    ? null
+                    : Math.min(currentStart, deltaStart),
+                currentEnd == null || deltaEnd == null ? null : Math.max(currentEnd, deltaEnd))));
   }
 }


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

There were two issues with the temporal extent on the landing page:

- unbounded interval ends were not handled properly;
- the JSON representation did not write ISO 8601, but milliseconds since epoch.

Since including this information in the landing page is an ldproxy extension (so that it can be shown in the HTML representation), this issue has not been noticed yet.