### PR TITLE
show feature title instead of id in items map popup

### DIFF
--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
@@ -183,6 +183,10 @@ public abstract class FeaturesView extends OgcApiDatasetView {
                   .url(uriBuilder().removeParameters("f").ensureParameter("f", "json").toString())
                   .build())
           .popup(Popup.HOVER_ID)
+          .featureTitles(
+              features().stream()
+                  .map(f -> Map.entry(f.getIdValue(), f.getName()))
+                  .collect(Collectors.toSet()))
           .styleUrl(Optional.ofNullable(styleUrl()))
           .removeZoomLevelConstraints(removeZoomLevelConstraints())
           .useBounds(true)

--- a/ogcapi-stable/ogcapi-html/src/main/java/de/ii/ogcapi/html/domain/MapClient.java
+++ b/ogcapi-stable/ogcapi-html/src/main/java/de/ii/ogcapi/html/domain/MapClient.java
@@ -82,6 +82,8 @@ public interface MapClient {
 
   Optional<Popup> getPopup();
 
+  Optional<Set<Entry<String, String>>> getFeatureTitles();
+
   Optional<Set<Entry<String, Collection<String>>>> getLayerGroupControl();
 
   @Value.Lazy

--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/index.jsx
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/index.jsx
@@ -16,7 +16,8 @@ const setStyleGeoJson = (
   maplibre,
   styleUrl,
   removeZoomLevelConstraints,
-  popup
+  popup,
+  featureTitles
 ) => {
   // eslint-disable-next-line no-undef
   fetch(styleUrl)
@@ -70,6 +71,7 @@ const setStyleGeoJson = (
         addPopup(
           map,
           maplibre,
+          featureTitles,
           dataStyle.layers
             .filter((layer) => isDataLayer(layer) === true)
             .map((layer) => layer.id)
@@ -166,7 +168,8 @@ const addData = (
   dataLayers,
   defaultStyle,
   fitBounds,
-  popup
+  popup,
+  featureTitles
 ) => {
   if (dataType === "geojson") {
     const features = getFeaturesWithIdAsProperty(data);
@@ -188,14 +191,14 @@ const addData = (
     }
 
     if (styleUrl) {
-      setStyleGeoJson(map, maplibre, styleUrl, removeZoomLevelConstraints, popup);
+      setStyleGeoJson(map, maplibre, styleUrl, removeZoomLevelConstraints, popup, featureTitles);
     } else {
       const defaultLayers = geoJsonLayers(defaultStyle);
 
       defaultLayers.forEach((layer) => map.addLayer(layer));
 
       if (popup === "HOVER_ID") {
-        addPopup(map, maplibre, hoverLayers);
+        addPopup(map, maplibre, featureTitles, hoverLayers);
       } else if (popup === "CLICK_PROPERTIES") {
         addPopupProps(
           map,
@@ -258,6 +261,7 @@ const MapLibreConfiguration = ({
   defaultStyle,
   fitBounds,
   popup,
+  featureTitles,
   custom,
   showCompass,
 }) => {
@@ -292,7 +296,8 @@ const MapLibreConfiguration = ({
               dataLayers,
               style,
               fitBounds,
-              popup
+              popup,
+              featureTitles
             );
           });
       } else {
@@ -306,7 +311,8 @@ const MapLibreConfiguration = ({
           dataLayers,
           style,
           fitBounds,
-          popup
+          popup,
+          featureTitles
         );
       }
     } else if (styleUrl) {
@@ -351,6 +357,7 @@ MapLibreConfiguration.propTypes = {
   }),
   fitBounds: PropTypes.bool,
   popup: PropTypes.oneOf(["HOVER_ID", "CLICK_PROPERTIES"]),
+  featureTitles: PropTypes.objectOf(PropTypes.string),
   custom: PropTypes.func,
   showCompass: PropTypes.bool,
 };
@@ -378,6 +385,7 @@ MapLibreConfiguration.defaultProps = {
   },
   fitBounds: true,
   popup: null,
+  featureTitles: {},
   custom: null,
   showCompass: true,
 };

--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/index.jsx
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/index.jsx
@@ -30,6 +30,7 @@ const MapLibre = ({
   defaultStyle,
   fitBoundsOptions,
   popup,
+  featureTitles,
   custom,
   showCompass,
   layerGroupControl,
@@ -74,6 +75,7 @@ const MapLibre = ({
         defaultStyle={defaultStyle}
         fitBounds={!drawBounds && bounds}
         popup={popup}
+        featureTitles={featureTitles}
         custom={custom}
       />
       {layerGroupControl && layerGroupControl.length > 0 && (

--- a/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/mapClient.mustache
+++ b/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/mapClient.mustache
@@ -69,6 +69,11 @@
     {{#popup}}
       popup: '{{.}}',
     {{/popup}}
+      featureTitles: {
+    {{#featureTitles}}
+        '{{key}}': '{{value}}',
+    {{/featureTitles}}
+      },
       layerGroupControl: [
     {{#layerGroupControl}}
         {


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on a PR over several days, please create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly (feel free to ask for help):
-->

### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

<!--
    Either reference the issue(s) that describe the changes introduced by this PR 
-->

The popup/popover in the map on the items page currently shows the id, which in most cases is not helpful for a user. This PR changes the popup to contain the title instead that is also used as heading in the list and can be configured using `featureTitleTemplate`.

<!--
    or shortly describe the changes below using bullet points
-->

